### PR TITLE
expand emails and bundles inline

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -20,6 +20,10 @@
       {
         "allowForLoopAfterthoughts": true
       }
+    ],
+    "radix": [
+      "error",
+      "as-needed"
     ]
   },
   "env": {

--- a/src/js/content/constants.js
+++ b/src/js/content/constants.js
@@ -14,7 +14,6 @@ export const CLASSES = {
   AVATAR_EMAIL_CLASS: 'email-with-avatar',
   AVATAR_CLASS: 'avatar',
   AVATAR_OPTION_CLASS: 'show-avatar-enabled',
-  BUNDLED_EMAIL_CLASS: 'bundled-email',
   BUNDLING_OPTION_CLASS: 'email-bundling-enabled',
   BUNDLE_PAGE_CLASS: 'bundle-page',
   BUNDLE_WRAPPER_CLASS: 'bundle-wrapper',
@@ -22,6 +21,5 @@ export const CLASSES = {
   CALENDAR_ATTACHMENT_CLASS: 'calendar-attachment',
   REMINDER_EMAIL_CLASS: 'reminder',
   UNREAD_BUNDLE_CLASS: 'contains-unread',
-  UNBUNDLED_PARENT_LABEL: 'Unbundled',
-  UNBUNDLED_EMAIL_CLASS: 'unbundled-email'
+  UNBUNDLED_PARENT_LABEL: 'Unbundled'
 };

--- a/src/js/content/dateLabels.js
+++ b/src/js/content/dateLabels.js
@@ -1,11 +1,10 @@
-import { CLASSES } from './constants';
-import { addClass, hasClass } from './utils';
+import { addClass } from './utils';
 
 export default {
   addDateLabels() {
     let lastLabel = null;
     this.cleanupDateLabels();
-    const emailElements = document.querySelectorAll(`.BltHke[role=main] .zA:not(.${CLASSES.BUNDLED_EMAIL_CLASS})`);
+    const emailElements = document.querySelectorAll('.BltHke[role=main] .zA:not([data-bundled="true"])');
     emailElements.forEach(emailEl => {
       const dateLabel = emailEl.getAttribute('data-date-label');
 
@@ -40,7 +39,7 @@ export default {
     if (sibling.className === 'time-row') {
       return true;
     }
-    if (!hasClass(sibling, CLASSES.BUNDLED_EMAIL_CLASS)) {
+    if (sibling.getAttribute('data-bundled') !== 'true') {
       return false;
     }
     return this.isEmptyDateLabel(sibling);
@@ -51,7 +50,7 @@ export default {
       if (row.nextSibling && row.nextSibling.className === 'time-row') {
         row.remove();
         // Check nextSibling recursively until reaching the next .time-row
-        // If all siblings are .bundled-email, then hide row
+        // If all siblings are bundled, then hide row
       } else if (this.isEmptyDateLabel(row)) {
         row.hidden = true;
       }

--- a/src/js/content/emailPreview.js
+++ b/src/js/content/emailPreview.js
@@ -1,0 +1,66 @@
+import {
+  addClass,
+  removeClass
+} from './utils';
+
+export default {
+  currentEmail: null,
+  hidePreview() {
+    this.previewShowing = false;
+  },
+  getPreviewPane() {
+    const paneSelector = '.BltHke.nH.oy8Mbf[role="main"]';
+    const previewSelector = `${paneSelector} .Nu.S3.aZ6`;
+    return document.querySelector(previewSelector);
+  },
+  emailClicked(clickedEmail) {
+    const previewPane = this.getPreviewPane();
+    const clickedCurrentEmail = clickedEmail && this.currentEmail && this.currentEmail === clickedEmail;
+    if (clickedCurrentEmail) {
+      if (this.previewShowing) {
+        this.hidePreviewPane(previewPane);
+      } else {
+        this.showPreviewPane(previewPane);
+      }
+    } else {
+      this.showPreview = true;
+    }
+  },
+  movePreviewPane(selectedEmail, previewPane) {
+    if (selectedEmail && previewPane) {
+      selectedEmail.parentNode.insertBefore(previewPane, selectedEmail.nextSibling);
+    }
+  },
+  showPreviewPane(previewPane) {
+    addClass(previewPane, 'show-preview');
+    this.showPreview = null;
+    this.previewShowing = true;
+  },
+  hidePreviewPane(previewPane) {
+    if (previewPane) {
+      removeClass(previewPane, 'show-preview');
+    }
+    this.previewShowing = false;
+  },
+  checkPreview() {
+    const previewPane = this.getPreviewPane();
+    if (this.currentEmail) {
+      const email = document.getElementById(this.currentEmail.getAttribute('id'));
+      if (!email) {
+        this.hidePreviewPane(previewPane);
+      }
+    }
+    const selectedEmail = document.querySelector('.BltHke.nH.oy8Mbf[role="main"] .zA.btb');
+    if (selectedEmail && selectedEmail.getAttribute('data-bundled') && this.previewShowing) {
+      this.hidePreviewPane(previewPane);
+    } else if (this.currentEmail !== selectedEmail) {
+      this.currentEmail = selectedEmail;
+      this.movePreviewPane(selectedEmail, previewPane);
+      if (this.showPreview) {
+        this.showPreviewPane(previewPane);
+      }
+    } else if (!this.previewShowing) {
+      this.hidePreviewPane(previewPane);
+    }
+  }
+};

--- a/src/js/content/emailUtils.js
+++ b/src/js/content/emailUtils.js
@@ -27,8 +27,6 @@ const getSnoozeDate = snoozeString => {
 };
 
 export const buildDateLabel = (dateString, snoozeString) => {
-  // const dateString = getRawDate(this.emailEl);
-  // const snoozed = this.isSnoozed();
   let date;
   if (snoozeString) {
     date = getSnoozeDate(snoozeString);

--- a/src/js/content/inbox.js
+++ b/src/js/content/inbox.js
@@ -1,22 +1,41 @@
 import Email from './email';
 import Bundle from './bundle';
-import { getTabs, isInInbox, observeForElement } from './utils';
+import {
+  addClass,
+  getTabs,
+  getCurrentBundle,
+  isInBundle,
+  isInInbox,
+  observeForElement,
+  removeClass
+} from './utils';
 import dateLabels from './dateLabels';
 import { getOptions, reloadOptions } from './options';
+import { CLASSES } from './constants';
+import emailPreview from './emailPreview';
 
 export default {
   async observeEmails() {
     const mainContainer = await observeForElement(document, '.AO');
     const observer = new MutationObserver(() => {
+      if (isInInbox()) {
+        let inbox = document.querySelector('.BltHke[role=main][data-inbox]');
+        if (!inbox) {
+          inbox = document.querySelector('.BltHke[role=main]');
+          inbox.setAttribute('data-inbox', true);
+        }
+      }
       reloadOptions();
       observer.disconnect();
+      emailPreview.checkPreview();
       this.processEmails();
+      this.moveBundleElement();
       observer.observe(mainContainer, { subtree: true, childList: true });
     });
     observer.observe(mainContainer, { subtree: true, childList: true });
   },
   processEmails() {
-    const emailElements = document.querySelectorAll('.BltHke[role=main] .zA:not(.bundle-wrapper)');
+    const emailElements = document.querySelectorAll(`.BltHke[role=main] .zA:not(.${CLASSES.BUNDLE_WRAPPER_CLASS}):not([data-nested-email])`);
     const isInInboxFlag = isInInbox();
     const tabs = getTabs();
     const options = getOptions();
@@ -29,7 +48,7 @@ export default {
       const emailElement = emailElements[i];
       const email = new Email(emailElement);
 
-      const emailLabels = email.getLabelTitles();
+      const emailLabels = email.getLabels().map(label => label.title);
 
       // Check for labels used for Tabs, and hide them from the row.
       if (currentTab) {
@@ -42,7 +61,7 @@ export default {
       }
 
       // Collect senders, message count and unread stats for each label
-      if (emailLabels.length && !email.isUnbundled()) {
+      if (emailLabels.length && email.isBundled) {
         const firstParticipant = email.getParticipantNames()[0];
         emailLabels.forEach(label => {
           if (!labelStats[label]) {
@@ -61,9 +80,8 @@ export default {
               isUnread: email.isUnread()
             });
           }
+          labelStats[label].email = email;
           labelStats[label].emailEl = email.emailEl;
-          labelStats[label].date = email.getRawDate();
-          labelStats[label].dateDisplay = email.getDateDisplay();
           if (email.isUnread()) {
             labelStats[label].containsUnread = true;
           }
@@ -72,7 +90,7 @@ export default {
     }
 
     // Update bundle stats
-    if (isInInboxFlag && options.emailBundling === 'enabled') {
+    if (isInInboxFlag && !isInBundle() && options.emailBundling === 'enabled') {
       Object.entries(labelStats).forEach(([label, stats]) => {
         const bundle = new Bundle(label, stats);
         bundle.updateStats();
@@ -89,9 +107,38 @@ export default {
     dateLabels.addDateLabels();
   },
   getBundledLabels() {
-    return Array.from(document.querySelectorAll('.BltHke[role=main] .bundle-wrapper')).reduce((bundledLabels, el) => {
+    return Array.from(document.querySelectorAll(`.BltHke[role=main] .${CLASSES.BUNDLE_WRAPPER_CLASS}`)).reduce((bundledLabels, el) => {
       bundledLabels[el.getAttribute('bundleLabel')] = el;
       return bundledLabels;
     }, {});
+  },
+  moveBundleElement() {
+    if (isInBundle()) {
+      const inboxPane = document.querySelector('.BltHke.nH.oy8Mbf[data-inbox="true"]');
+      const bundlePane = document.querySelector('.BltHke.nH.oy8Mbf[role="main"]');
+
+      if (inboxPane && bundlePane && inboxPane !== bundlePane && !bundlePane.getAttribute('data-navigating')) {
+        const bundleId = getCurrentBundle();
+        if (!inboxPane.querySelector(`.BltHke[data-bundle="${bundleId}"]`)) {
+          inboxPane.style.display = '';
+          bundlePane.setAttribute('data-bundle', bundleId);
+          const bundleRow = inboxPane.querySelector(`.zA.${CLASSES.BUNDLE_WRAPPER_CLASS}[data-bundle="${bundleId}"]`);
+          if (bundleRow) {
+            bundleRow.parentNode.insertBefore(bundlePane, bundleRow.nextSibling);
+            addClass(bundlePane, 'nested-bundle');
+          }
+        }
+      }
+    }
+  },
+  replaceBundle() {
+    const inboxPane = document.querySelector('.BltHke.nH.oy8Mbf[data-inbox="true"]');
+    const nestedBundle = document.querySelector('.nested-bundle');
+    if (inboxPane && nestedBundle) {
+      inboxPane.parentNode.appendChild(nestedBundle);
+      inboxPane.style.display = 'none';
+      removeClass(nestedBundle, '.nested-bundle');
+      nestedBundle.setAttribute('data-navigating', true);
+    }
   }
 };

--- a/src/js/content/index.js
+++ b/src/js/content/index.js
@@ -1,9 +1,9 @@
 import leftNav from './leftNav';
 import navigation from './navigation';
-import emails from './emails';
+import inbox from './inbox';
 
 function initInboxReborn() {
-  emails.observeEmails();
+  inbox.observeEmails();
   navigation.init();
   leftNav.init();
 }

--- a/src/js/content/leftNav.js
+++ b/src/js/content/leftNav.js
@@ -1,4 +1,5 @@
-import { addClass, removeClass } from './utils';
+import { addClass, queryParentSelector, removeClass } from './utils';
+import inbox from './inbox';
 
 export default {
   loadedMenu: false,
@@ -34,7 +35,7 @@ export default {
         placeholder.style.cssText = 'padding: 0; border: 0;';
         parent.insertBefore(placeholder, refer);
 
-        const inbox = this.menuItems.find(item => item.label === 'inbox').node;
+        const inboxEl = this.menuItems.find(item => item.label === 'inbox').node;
         const snoozed = this.menuItems.find(item => item.label === 'snoozed').node;
         const done = this.menuItems.find(item => item.label === 'archive').node;
 
@@ -50,17 +51,17 @@ export default {
         const newNode = document.createElement('div');
         addClass(newNode, 'TK');
         addClass(newNode, 'main-menu');
-        newNode.appendChild(inbox);
+        newNode.appendChild(inboxEl);
         newNode.appendChild(snoozed);
         newNode.appendChild(done);
         parent.insertBefore(newNode, refer);
 
-        this.setupClickEventForNodes(this.menuItems.map(item => item.node));
-
         const chatContainer = document.querySelector('div[aria-label="Hangouts"][role="complementary"]');
-        const leftHandChat = chatContainer && this.queryParentSelector(chatContainer, '.aeN');
+        const leftHandChat = chatContainer && queryParentSelector(chatContainer, '.aeN');
         addClass(document.body, leftHandChat ? 'left-hand-chat' : 'right-hand-chat');
         moreMenu.click();
+        this.setupClickEventForNodes();
+        this.observeLabelNav();
         observer.disconnect();
       }
 
@@ -71,28 +72,36 @@ export default {
     });
     observer.observe(document.body, { subtree: true, childList: true });
   },
-  setupClickEventForNodes(nodes) {
-    nodes.map(node => node.addEventListener('click', () => this.activateMenuItem(node, nodes)));
+  observeLabelNav() {
+    this.applyLabelColors();
+    const observer = new MutationObserver(() => {
+      this.applyLabelColors();
+      this.setupClickEventForNodes();
+    });
+    const leftNavContainer = document.querySelector('.ajl.aib .wT');
+    observer.observe(leftNavContainer, { subtree: true, childList: true });
   },
-  activateMenuItem(target, nodes) {
-    nodes.map(node => removeClass(node.firstChild, 'nZ'));
-    addClass(target.firstChild, 'nZ');
+  applyLabelColors() {
+    document.querySelectorAll('.qj').forEach(labelIcon => {
+      if (labelIcon.style.borderColor) {
+        const color = labelIcon.style.borderColor;
+        const text = labelIcon.parentNode.querySelector('a');
+        text.style.color = color;
+        labelIcon.style.filter = `drop-shadow(0 0 0 ${color}) saturate(300%)`;
+        labelIcon.style.borderWidth = 0;
+      }
+    });
+  },
+  setupClickEventForNodes() {
+    const leftNavItems = document.querySelectorAll('.TN');
+    leftNavItems.forEach(item => item.addEventListener('click', this.activateMenuItem));
+  },
+  activateMenuItem(event) {
+    inbox.replaceBundle();
+    document.querySelectorAll('.nZ').forEach(el => removeClass(el, 'nZ'));
+    addClass(event.currentTarget.parentNode, 'nZ');
   },
   findMenuItem(itemSelector) {
-    return this.queryParentSelector(document.querySelector(itemSelector), '.aim');
-  },
-  queryParentSelector(el, selector) {
-    if (!el) {
-      return null;
-    }
-    let parent = el.parentElement;
-    while (!parent.matches(selector)) {
-      parent = parent.parentElement;
-      if (!parent) {
-        return null;
-      }
-    }
-    return parent;
+    return queryParentSelector(document.querySelector(itemSelector), '.aim');
   }
-
 };

--- a/src/js/content/navigation.js
+++ b/src/js/content/navigation.js
@@ -2,18 +2,25 @@ import {
   addClass,
   getMyEmailAddress,
   isInBundle,
+  isInInbox,
   isTypable,
   observeForElement,
+  openInbox,
   removeClass
 } from './utils';
 import leftNav from './leftNav';
-import { getOptions } from './options';
+import inbox from './inbox';
+import { getOptions, reloadOptions } from './options';
 import { CLASSES } from './constants';
 
 export default {
   init() {
+    reloadOptions();
     this.updateFloatingButtons();
     this.updateHeader();
+    if (!isInInbox()) { // always make sure we start on the main inbox page so we can find the right email container
+      openInbox();
+    }
     window.addEventListener('hashchange', this.handleHashChange);
   },
   async updateHeader() {
@@ -26,7 +33,18 @@ export default {
     if (gSuiteLogo) {
       addClass(document.body, 'g-suite');
     }
+    this.handleSearchSubmit();
     this.handleHashChange();
+  },
+  async handleSearchSubmit() {
+    const searchInput = await observeForElement(document, '.gb_sf');
+    searchInput.addEventListener('keydown', event => {
+      if (event.code === 'Enter') {
+        inbox.replaceBundle();
+      }
+    });
+    const searchButton = document.querySelector('.gb_Bf');
+    searchButton.addEventListener('click', inbox.replaceBundle);
   },
   handleHashChange() {
     let { hash } = window.location;
@@ -44,7 +62,7 @@ export default {
         title = 'gmail';
       }
     }
-    const headerElement = document.querySelector('header').parentElement.parentElement;
+    const headerElement = document.querySelector('header') && document.querySelector('header').parentElement.parentElement;
     if (headerElement) {
       headerElement.setAttribute('pageTitle', title);
     }

--- a/src/js/content/options.js
+++ b/src/js/content/options.js
@@ -24,7 +24,7 @@ export const reloadOptions = () => {
   } else if (options.emailBundling === 'disabled') {
     removeClass(document.body, CLASSES.BUNDLING_OPTION_CLASS);
     // Unbundle emails
-    document.querySelectorAll(`.${CLASSES.BUNDLED_EMAIL_CLASS}`).forEach(emailEl => removeClass(emailEl, CLASSES.BUNDLED_EMAIL_CLASS));
+    document.querySelectorAll('[data-bundled="true"]').forEach(emailEl => emailEl.removeAttribute('data-bundled'));
     // Remove bundle wrapper rows
     document.querySelectorAll(`.${CLASSES.BUNDLE_WRAPPER_CLASS}`).forEach(bundleEl => bundleEl.remove());
   }

--- a/src/js/content/utils.js
+++ b/src/js/content/utils.js
@@ -1,16 +1,21 @@
+import { CLASSES } from './constants';
+
 // ---- HTML Elements ---- \\
-export const observeForElement = (el, selector) => new Promise(
+export const observeForCondition = (el, condition) => new Promise(
   resolve => {
     const observer = new MutationObserver(() => {
-      const findEl = el.querySelector(selector);
-      if (findEl) {
+      const satisified = condition();
+      if (satisified) {
         observer.disconnect();
-        resolve(findEl);
+        resolve(satisified);
       }
     });
     observer.observe(el, { subtree: true, childList: true });
   }
 );
+
+export const observeForElement = (el, selector) => observeForCondition(el, () => el.querySelector(selector));
+export const observeForRemoval = (el, selector) => observeForCondition(el, () => !el.querySelector(selector));
 
 export const htmlToElements = html => {
   const template = document.createElement('template');
@@ -23,17 +28,33 @@ export const isTypable = element => {
   return ['INPUT', 'TEXTAREA'].includes(element.tagName) || (role === 'textbox');
 };
 
+// export const pixelsToInt = pixels => parseInt(pixels.replace('px'));
+
+export const queryParentSelector = (el, selector) => {
+  if (!el) {
+    return null;
+  }
+  let parent = el.parentElement;
+  while (!parent.matches(selector)) {
+    parent = parent.parentElement;
+    if (!parent) {
+      return null;
+    }
+  }
+  return parent;
+};
+
 // ---- Classes ---- \\
-export const hasClass = (element, className) => element.classList.contains(className);
+export const hasClass = (element, className) => element && element.classList.contains(className);
 
 export const addClass = (element, className) => {
-  if (!hasClass(element, className)) {
+  if (element && !hasClass(element, className)) {
     element.classList.add(className);
   }
 };
 
 export const removeClass = (element, className) => {
-  if (hasClass(element, className)) {
+  if (element && hasClass(element, className)) {
     element.classList.remove(className);
   }
 };
@@ -42,7 +63,10 @@ export const removeClass = (element, className) => {
 export const getTabs = () => Array.from(document.querySelectorAll('.aKz')).map(el => el.innerText);
 export const isInInbox = () => document.querySelector('.nZ a[title=Inbox]') !== null;
 export const isInBundle = () => document.location.hash.match(/#search\/in%3Ainbox\+label%3A/g) !== null;
-export const checkImportantMarkers = () => document.querySelector('.zA:not(.bundle-wrapper) td.WA.xY');
+export const getCurrentBundle = () => document.location.hash.replace('#search/in%3Ainbox+label%3A', '');
+export const checkImportantMarkers = () => document.querySelector(`.zA:not(.${CLASSES.BUNDLE_WRAPPER_CLASS}) td.WA.xY`);
+export const openBundle = bundleId => { window.location.href = `#search/in%3Ainbox+label%3A${bundleId}`; };
+export const openInbox = () => { window.location.href = '#inbox'; };
 
 export const getMyEmailAddress = () => {
   if (document.querySelector('.gb_tb') && document.querySelector('.gb_tb').innerText) {

--- a/src/scss/bundle.scss
+++ b/src/scss/bundle.scss
@@ -1,5 +1,6 @@
 .zA.bundle-wrapper {
 	.bundle-image {
+		order: 0;
 		img {
 			width: 28px;
 			padding: 0 6px 0 10px;

--- a/src/scss/content.scss
+++ b/src/scss/content.scss
@@ -39,7 +39,6 @@
 .ar4 { //main-container
 	max-width: 1200px;
 	margin: 0 auto;
-	padding-left: 16px;
 
 	.aeJ { //main-content-container
 		background-color: transparent;

--- a/src/scss/email-list.scss
+++ b/src/scss/email-list.scss
@@ -1,5 +1,23 @@
 @import 'email-list-images';
 
+.Nu.S3.aZ6 { //preview-pane
+	overflow: auto;
+	box-shadow: 0 3px 4px rgba(0,0,0,.24);
+
+	&:not(.show-preview) {
+		//need !important to override inline styles
+		flex-grow: 0 !important;
+		height: 0 !important;
+	}
+	.if > .byY { //email subject header
+		padding-left: 20px;
+	}
+
+	.ii.gt { //email-body
+		padding-right: 56px;
+	}
+}
+
 .ae4 { //email-list-container
 	margin-bottom: 40px;
 	.Cp { //email-table-container
@@ -127,7 +145,7 @@
 						}
 					}
 				}
-				&.bundled-email {
+				&[data-bundled="true"] {
 					display: none;
 				}
 				.email-bundling-enabled.bundle-page & {
@@ -158,13 +176,52 @@
 						margin-right: 10px;
 					}
 				}
+			}
+		}
 
-				&.reminder {
-					.WA { //important-indicator-column
-						visibility: hidden;
-					}
+		.BltHke.nH.oy8Mbf { //main-email-container
+			&.nested-bundle {
+				padding: 0 20px;
+				height: auto;
+				background-color: lightgray;
+
+				.Nt { //bottom-border
+					display: none;
 				}
 			}
 		}
 	}
+}
+
+.BltHke.nH.oy8Mbf { //main-email-container
+	&[data-navigating]::after {
+		content: '';
+		height: 100%;
+		width: 100%;
+		background: #F2F2F2;
+		position: absolute;
+		padding-top: 10px;
+		z-index: 3;
+	}
+
+	&[data-navigating]::before {
+		content: '';
+		box-sizing: border-box;
+		position: absolute;
+		top: 50%;
+		left: 50%;
+		width: 40px;
+		height: 40px;
+		margin-top: -20px;
+		margin-left: -20px;
+		border-radius: 50%;
+		border: 2px solid #fff;
+		border-top-color: #333;
+		animation: spinner .8s linear infinite;
+		z-index: 4;
+	}
+}
+
+@keyframes spinner {
+  to {transform: rotate(360deg);}
 }


### PR DESCRIPTION
### Expanding Bundles Inline - resolves #9
* clicking a collapsed bundle row stil navigates to the bundle search results
* track the email container for the main inbox and don't hide it when navigating to a bundle search.  Simplest solution for this at the moment is to always start on the inbox page, so we currently always redirect on load if not loading in to the inbo
* move the bundle email container right after the bundle row in the inbox table
* if there's another bundle open when clicking a bundle row, we navigate back to the inbox page to close the open bundle
* we then wait for the old bundle element to be removed before go to the next one
* always close email previews when opening/closing bundles, hard to manage the two different preview panes and which is open
* move the bundle email container back when navigating to another email page like Done or Snoozed or when searching

### Email Previews - resolves #10
* clicking an email row will move the preview pane after that email and show it to act like the email expanded
* clicking it again will hide the preview
* move the preview as the selected email changes
* don't show previews if a bundled email gets selected (i.e. when using the arrow keys to navigate emails)
* ignore clicks on the columns with buttons in them (checkbox, pin, action bar, etc)
* if a bundle is expanded, when clicking a row outside the bundle, navigate back to the inbox
* remove main container left padding now that emails are shown inline

### Other Updates
* refactor how dates and labels are shared with bundles and the date label builder
* swap to data attributes in a variety of spots to avoid gmail removing our classes
* combine unbundled label logic in with the rest of bundle processing
* apply label colors to the label text in the left nav instead of the default border; doesn't work well with very light label colors
* fix bundle row positioning of image