### PR TITLE
[#37] refactor preview and bundles; [#38] re-click actions on emails outside of a bundle

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,13 @@
 {
   "extends": "airbnb-base",
   "rules": {
+    "array-bracket-spacing": [
+      "error",
+      "always",
+      {
+        "singleValue": false
+      }
+    ],
     "arrow-parens": [
       "error",
       "as-needed"

--- a/src/js/content/bundle.js
+++ b/src/js/content/bundle.js
@@ -36,7 +36,7 @@ export default class Bundle {
     const { dateLabel, dateDisplay, rawDate } = email.dateInfo;
 
     const bundleWrapper = htmlToElements(`
-        <div class="zA yO ${BUNDLE_WRAPPER_CLASS}" bundleLabel="${this.label}" data-bundle=${bundleId} data-date-label="${dateLabel}">
+        <div class="zA yO ${BUNDLE_WRAPPER_CLASS}" bundleLabel="${this.label}" data-inbox=${bundleId} data-date-label="${dateLabel}">
           <div class="PF xY"></div>
           <div class="oZ-x3 xY aid bundle-image">
             <img src="${bundleImage}" ${bundleTitleColor ? `style="filter: drop-shadow(0 0 0 ${bundleTitleColor}) saturate(300%)"` : ''}/>
@@ -68,7 +68,7 @@ export default class Bundle {
       }
       if (clickedClosedBundle) {
         if (isInBundleFlag) {
-          await observeForRemoval(document, '.nested-bundle');
+          await observeForRemoval(document, '[data-pane="bundle"]');
         }
         openBundle(bundleId);
       }
@@ -110,7 +110,7 @@ export default class Bundle {
     labels.forEach(label => {
       if (label.title === this.label) {
         // Ignore default label color, light gray
-        if (label.color !== 'rgb(221, 221, 221)') {
+        if (label.color !== 'rgb(102, 102, 102)') {
           bundleTitleColor = label.color;
         }
       }

--- a/src/js/content/bundle.js
+++ b/src/js/content/bundle.js
@@ -1,6 +1,5 @@
-import { CLASSES } from './constants';
+import { CLASSES, SELECTORS } from './constants';
 import emailPreview from './emailPreview';
-import inbox from './inbox';
 import {
   addClass,
   checkImportantMarkers,
@@ -13,11 +12,14 @@ import {
   removeClass
 } from './utils';
 
+const { BUNDLE_WRAPPER_CLASS, UNREAD_BUNDLE_CLASS } = CLASSES;
+const { EMAIL_CONTAINER } = SELECTORS;
+
 export default class Bundle {
   constructor(label, stats) {
     this.label = label;
     this.stats = stats;
-    this.element = document.querySelector(`.BltHke[role=main] .${CLASSES.BUNDLE_WRAPPER_CLASS}[bundleLabel="${label}"]`);
+    this.element = document.querySelector(`${EMAIL_CONTAINER}[role=main] .${BUNDLE_WRAPPER_CLASS}[bundleLabel="${label}"]`);
     if (stats.count === 0 && this.element) {
       this.element.remove();
     } else if (!this.element) {
@@ -34,7 +36,7 @@ export default class Bundle {
     const { dateLabel, dateDisplay, rawDate } = email.dateInfo;
 
     const bundleWrapper = htmlToElements(`
-        <div class="zA yO ${CLASSES.BUNDLE_WRAPPER_CLASS}" bundleLabel="${this.label}" data-bundle=${bundleId} data-date-label="${dateLabel}">
+        <div class="zA yO ${BUNDLE_WRAPPER_CLASS}" bundleLabel="${this.label}" data-bundle=${bundleId} data-date-label="${dateLabel}">
           <div class="PF xY"></div>
           <div class="oZ-x3 xY aid bundle-image">
             <img src="${bundleImage}" ${bundleTitleColor ? `style="filter: drop-shadow(0 0 0 ${bundleTitleColor}) saturate(300%)"` : ''}/>
@@ -59,6 +61,8 @@ export default class Bundle {
       const currentBundleId = getCurrentBundle(); // will be null when in inbox
       const isInBundleFlag = isInBundle();
       const clickedClosedBundle = bundleId !== currentBundleId;
+
+      emailPreview.hidePreview();
       if (isInBundleFlag) {
         openInbox(); // opening the inbox closes the open bundle
       }
@@ -66,23 +70,8 @@ export default class Bundle {
         if (isInBundleFlag) {
           await observeForRemoval(document, '.nested-bundle');
         }
-        emailPreview.hidePreview();
         openBundle(bundleId);
       }
-
-      // alternative implementation that navigates directly between bundles
-      // however, we have to reset the UI to the normal bundle display briefly,
-      // similar to what's done when navigating to other pages which causes a brief full page flash of gray
-      // const clickedOpen = bundleId === currentBundleId;
-      // if (clickedOpenBundle) {
-      //   openInbox();
-      // } else {
-      //   if (isInBundleFlag) {
-      //     inbox.replaceBundle();
-      //   }
-      //   emailPreview.hidePreview();
-      //   openBundle(bundleId);
-      // }
     };
 
     if (emailEl && emailEl.parentNode) {
@@ -165,9 +154,9 @@ export default class Bundle {
 
   checkUnread() {
     if (this.stats.containsUnread) {
-      addClass(this.element, CLASSES.UNREAD_BUNDLE_CLASS);
+      addClass(this.element, UNREAD_BUNDLE_CLASS);
     } else {
-      removeClass(this.element, CLASSES.UNREAD_BUNDLE_CLASS);
+      removeClass(this.element, UNREAD_BUNDLE_CLASS);
     }
   }
 

--- a/src/js/content/constants.js
+++ b/src/js/content/constants.js
@@ -23,3 +23,9 @@ export const CLASSES = {
   UNREAD_BUNDLE_CLASS: 'contains-unread',
   UNBUNDLED_PARENT_LABEL: 'Unbundled'
 };
+
+export const SELECTORS = {
+  EMAIL_ROW: '.zA',
+  EMAIL_CONTAINER: '.BltHke', // could add .nH.oy8Mbf
+  PREVIEW_PANE: '.Nu.S3.aZ6'
+};

--- a/src/js/content/dateLabels.js
+++ b/src/js/content/dateLabels.js
@@ -7,16 +7,19 @@ export default {
   addDateLabels() {
     let lastLabel = null;
     this.cleanupDateLabels();
-    const emailElements = document.querySelectorAll(`${EMAIL_CONTAINER}[role=main] ${EMAIL_ROW}:not([data-bundled="true"])`);
-    emailElements.forEach(emailEl => {
-      const dateLabel = emailEl.getAttribute('data-date-label');
+    const emailContainer = document.querySelector(`${EMAIL_CONTAINER}[role=main]`);
+    if (emailContainer) {
+      const emailElements = emailContainer.querySelectorAll(`${EMAIL_ROW}:not([data-inbox="bundled"])`);
+      emailElements.forEach(emailEl => {
+        const dateLabel = emailEl.getAttribute('data-date-label');
 
-      // Add date label if it's a new label
-      if (dateLabel !== lastLabel) {
-        this.addDateLabel(emailEl, dateLabel);
-        lastLabel = dateLabel;
-      }
-    });
+        // Add date label if it's a new label
+        if (dateLabel !== lastLabel) {
+          this.addDateLabel(emailEl, dateLabel);
+          lastLabel = dateLabel;
+        }
+      });
+    }
   },
   addDateLabel(email, label) {
     if (email.previousSibling && email.previousSibling.className === 'time-row') {
@@ -42,7 +45,7 @@ export default {
     if (sibling.className === 'time-row') {
       return true;
     }
-    if (sibling.getAttribute('data-bundled') !== 'true') {
+    if (sibling.getAttribute('data-inbox') !== 'bundled') {
       return false;
     }
     return this.isEmptyDateLabel(sibling);

--- a/src/js/content/dateLabels.js
+++ b/src/js/content/dateLabels.js
@@ -1,10 +1,13 @@
 import { addClass } from './utils';
+import { SELECTORS } from './constants';
+
+const { EMAIL_CONTAINER, EMAIL_ROW } = SELECTORS;
 
 export default {
   addDateLabels() {
     let lastLabel = null;
     this.cleanupDateLabels();
-    const emailElements = document.querySelectorAll('.BltHke[role=main] .zA:not([data-bundled="true"])');
+    const emailElements = document.querySelectorAll(`${EMAIL_CONTAINER}[role=main] ${EMAIL_ROW}:not([data-bundled="true"])`);
     emailElements.forEach(emailEl => {
       const dateLabel = emailEl.getAttribute('data-date-label');
 

--- a/src/js/content/email.js
+++ b/src/js/content/email.js
@@ -125,10 +125,6 @@ export default class Email {
   processBundle() {
     const options = getOptions();
     this.isBundled = this.emailEl.getAttribute('data-bundled') === 'true';
-    const alreadyProcessed = this.isBundled;
-    if (alreadyProcessed) {
-      return;
-    }
 
     const tabs = getTabs();
     const labels = this.getLabels().filter(label => !tabs.includes(label.title));
@@ -148,6 +144,7 @@ export default class Email {
       const hideEmailStyle = document.getElementById(styleId);
 
       if (labels.length && !isStarred && !isUnbundled) {
+        this.emailEl.removeAttribute('data-inbox');
         this.emailEl.setAttribute('data-bundled', true);
         this.isBundled = true;
         // Insert style node to avoid bundled emails appearing briefly in inbox during redraw
@@ -159,7 +156,9 @@ export default class Email {
           style.appendChild(document.createTextNode(`.nH.ar4.z .zA[id="${this.emailEl.id}"] { display: none; }`));
         }
       } else {
+        this.emailEl.removeAttribute('data-bundled');
         this.emailEl.setAttribute('data-inbox', true);
+        this.isBundled = false;
         if (hideEmailStyle) {
           document.getElementById(styleId).remove();
         }

--- a/src/js/content/email.js
+++ b/src/js/content/email.js
@@ -14,19 +14,18 @@ import {
   isInBundle,
   isInInbox,
   openInbox,
-  queryParentSelector
+  queryParentSelector,
+  observeForRemoval
 } from './utils';
 
-const STYLE_NODE_ID_PREFIX = 'hide-email-';
-
 export default class Email {
-  constructor(emailEl) {
+  constructor(emailEl, prevDate) {
     this.emailEl = emailEl;
 
     this.processIcon();
     this.processBundle();
     this.processCalendar();
-    this.processDate();
+    this.processDate(prevDate);
     this.setupPreview();
   }
 
@@ -48,6 +47,10 @@ export default class Email {
 
   getParticipantNames() {
     return this.getParticipants().map(node => node.getAttribute('name'));
+  }
+
+  isBundled() {
+    return this.emailEl.getAttribute('data-inbox') === 'bundled';
   }
 
   isReminder() {
@@ -105,18 +108,24 @@ export default class Email {
     }
   }
 
-  processDate() {
+  processDate(prevDate) {
     const dateElement = this.emailEl.querySelector('.xW.xY span');
     const dateDisplay = dateElement && dateElement.innerText;
     const rawDate = dateElement && dateElement.getAttribute('title');
+    let date = new Date(rawDate);
     const snoozeElement = this.emailEl.querySelector('.by1.cL');
     const snoozeString = snoozeElement && snoozeElement.innerText;
+    const isSnoozed = snoozeString || (prevDate && date < prevDate);
+    if (isSnoozed) {
+      date = prevDate || new Date();
+    }
 
-    const dateLabel = buildDateLabel(rawDate, snoozeString);
+    const dateLabel = buildDateLabel(date);
     this.dateInfo = {
-      rawDate,
+      date,
       dateLabel,
-      dateDisplay
+      dateDisplay,
+      rawDate
     };
 
     this.emailEl.setAttribute('data-date-label', dateLabel);
@@ -124,45 +133,21 @@ export default class Email {
 
   processBundle() {
     const options = getOptions();
-    this.isBundled = this.emailEl.getAttribute('data-bundled') === 'true';
 
     const tabs = getTabs();
     const labels = this.getLabels().filter(label => !tabs.includes(label.title));
     const labelTitles = labels.map(label => label.title);
-    this.emailEl.setAttribute('data-bundle', labelTitles.join(','));
-    if (queryParentSelector(this.emailEl, '.nested-bundle')) {
-      this.emailEl.setAttribute('data-nested-email', true);
-    }
 
     // only process bundles on the inbox page
     if (options.emailBundling === 'enabled' && !isInBundle() && isInInbox()) {
       const starContainer = this.emailEl.querySelector('.T-KT');
-      // const isStarred = starContainer && starContainer.title !== 'Not starred';
       const isStarred = hasClass(starContainer, 'T-KT-Jp');
       const isUnbundled = labelTitles.some(title => title.includes(CLASSES.UNBUNDLED_PARENT_LABEL));
 
-      const styleId = `${STYLE_NODE_ID_PREFIX}-${this.emailEl.id}`;
-      const hideEmailStyle = document.getElementById(styleId);
-
       if (labels.length && !isStarred && !isUnbundled) {
-        this.emailEl.removeAttribute('data-inbox');
-        this.emailEl.setAttribute('data-bundled', true);
-        this.isBundled = true;
-        // Insert style node to avoid bundled emails appearing briefly in inbox during redraw
-        if (!hideEmailStyle) {
-          const style = document.createElement('style');
-          document.head.appendChild(style);
-          style.id = styleId;
-          style.type = 'text/css';
-          style.appendChild(document.createTextNode(`.nH.ar4.z .zA[id="${this.emailEl.id}"] { display: none; }`));
-        }
+        this.emailEl.setAttribute('data-inbox', 'bundled');
       } else {
-        this.emailEl.removeAttribute('data-bundled');
-        this.emailEl.setAttribute('data-inbox', true);
-        this.isBundled = false;
-        if (hideEmailStyle) {
-          document.getElementById(styleId).remove();
-        }
+        this.emailEl.setAttribute('data-inbox', 'email');
         if (isUnbundled) {
           labels.forEach(label => {
             if (label.title.includes(CLASSES.UNBUNDLED_PARENT_LABEL)) {
@@ -215,15 +200,28 @@ export default class Email {
   setupPreview() {
     const previewProcessed = this.emailEl.getAttribute('data-preview-enabled');
     if (previewProcessed !== 'true') {
-      const ignoreColumns = ['oZ-x3', 'apU', 'bq4'];
-      this.emailEl.addEventListener('click', event => {
-        const clickColumn = queryParentSelector(event.target, '.xY');
-        if (clickColumn && ignoreColumns.some(col => hasClass(clickColumn, col))) {
-          return;
-        }
-        emailPreview.emailClicked(this.emailEl);
+      const ignoreColumns = [ 'oZ-x3', 'apU', 'bq4' ];
+      this.emailEl.addEventListener('click', async event => {
         if (this.emailEl.getAttribute('data-inbox') && isInBundle()) {
           openInbox();
+          emailPreview.hidePreview();
+          await observeForRemoval(document, '[data-pane="bundle"]');
+          const clickColumn = queryParentSelector(event.target, '.xY');
+          if (clickColumn && ignoreColumns.some(col => hasClass(clickColumn, col))) {
+            const clickSelector = `${event.target.tagName}.${Array.from(event.target.classList).join('.')}`;
+            const clickTarget = this.emailEl.querySelector(clickSelector);
+            if (clickTarget) {
+              clickTarget.click();
+            }
+          } else {
+            emailPreview.emailClicked(this.emailEl);
+          }
+        } else {
+          const clickColumn = queryParentSelector(event.target, '.xY');
+          if (clickColumn && ignoreColumns.some(col => hasClass(clickColumn, col))) {
+            return;
+          }
+          emailPreview.emailClicked(this.emailEl);
         }
       });
       this.emailEl.setAttribute('data-preview-enabled', true);

--- a/src/js/content/email.js
+++ b/src/js/content/email.js
@@ -137,7 +137,8 @@ export default class Email {
     // only process bundles on the inbox page
     if (options.emailBundling === 'enabled' && !isInBundle() && isInInbox()) {
       const starContainer = this.emailEl.querySelector('.T-KT');
-      const isStarred = starContainer && starContainer.title !== 'Not starred';
+      // const isStarred = starContainer && starContainer.title !== 'Not starred';
+      const isStarred = hasClass(starContainer, 'T-KT-Jp');
       const isUnbundled = labelTitles.some(title => title.includes(CLASSES.UNBUNDLED_PARENT_LABEL));
 
       const styleId = `${STYLE_NODE_ID_PREFIX}-${this.emailEl.id}`;

--- a/src/js/content/emailPreview.js
+++ b/src/js/content/emailPreview.js
@@ -1,28 +1,49 @@
 import {
   addClass,
-  removeClass
+  removeClass,
+  observeForElement
 } from './utils';
+import { SELECTORS } from './constants';
+
+const { EMAIL_CONTAINER, EMAIL_ROW, PREVIEW_PANE } = SELECTORS;
+
+/* Issues
+* archiving emails in a bundle from oldest to newest doesn't automatically update preview pane
+* navigating quickly between two bundles can cause weird things
+* previews still aren't always consistent - might need to
+*/
 
 export default {
   currentEmail: null,
   hidePreview() {
-    this.previewShowing = false;
+    this.showPreview = false;
   },
-  getPreviewPane() {
-    const paneSelector = '.BltHke.nH.oy8Mbf[role="main"]';
-    const previewSelector = `${paneSelector} .Nu.S3.aZ6`;
+  getPreviewPane(emailEl) {
+    let previewSelector;
+    if (emailEl.getAttribute('data-inbox')) {
+      previewSelector = `${EMAIL_CONTAINER} ${PREVIEW_PANE}[data-inbox]`;
+    } else {
+      // this catches both emails in nested bundles and emails on non-inbox pages (like snoozed/done)
+      previewSelector = `${EMAIL_CONTAINER}[role="main"] ${PREVIEW_PANE}`;
+    }
     return document.querySelector(previewSelector);
   },
-  emailClicked(clickedEmail) {
-    const previewPane = this.getPreviewPane();
+  async emailClicked(clickedEmail) {
+    const previewPane = this.getPreviewPane(clickedEmail);
     const clickedCurrentEmail = clickedEmail && this.currentEmail && this.currentEmail === clickedEmail;
     if (clickedCurrentEmail) {
       if (this.previewShowing) {
+        this.showPreview = false;
         this.hidePreviewPane(previewPane);
       } else {
+        await observeForElement(previewPane, '.UG');
+        this.showPreview = true;
         this.showPreviewPane(previewPane);
       }
     } else {
+      // clicking the email changes the selected email automatically
+      // set showPreview so that checkPreview will make it visible
+      // when it processes the new selected email
       this.showPreview = true;
     }
   },
@@ -31,9 +52,24 @@ export default {
       selectedEmail.parentNode.insertBefore(previewPane, selectedEmail.nextSibling);
     }
   },
+  restorePreview(previewPane) {
+    let containerSelector;
+    if (previewPane.getAttribute('data-inbox')) {
+      containerSelector = `${EMAIL_CONTAINER}[data-inbox]`;
+    } else if (previewPane.getAttribute('data-bundle')) {
+      containerSelector = `${EMAIL_CONTAINER}[data-bundle]`;
+    } else {
+      containerSelector = `${EMAIL_CONTAINER}[role=main]:not([data-inbox]):not([data-bundle])`;
+    }
+
+    const container = document.querySelector(containerSelector);
+    if (container) {
+      const nested = document.querySelector(`${containerSelector} > .Nr.UI`);
+      nested.appendChild(previewPane);
+    }
+  },
   showPreviewPane(previewPane) {
     addClass(previewPane, 'show-preview');
-    this.showPreview = null;
     this.previewShowing = true;
   },
   hidePreviewPane(previewPane) {
@@ -42,25 +78,35 @@ export default {
     }
     this.previewShowing = false;
   },
-  checkPreview() {
-    const previewPane = this.getPreviewPane();
+  hideIfCurrentEmailRemoved() {
     if (this.currentEmail) {
-      const email = document.getElementById(this.currentEmail.getAttribute('id'));
-      if (!email) {
+      const currentEmailEl = document.getElementById(this.currentEmail.getAttribute('id'));
+      const previewPane = this.getPreviewPane(this.currentEmail);
+      if (!currentEmailEl) {
+        this.currentEmail = null;
         this.hidePreviewPane(previewPane);
       }
     }
-    const selectedEmail = document.querySelector('.BltHke.nH.oy8Mbf[role="main"] .zA.btb');
-    if (selectedEmail && selectedEmail.getAttribute('data-bundled') && this.previewShowing) {
-      this.hidePreviewPane(previewPane);
-    } else if (this.currentEmail !== selectedEmail) {
-      this.currentEmail = selectedEmail;
-      this.movePreviewPane(selectedEmail, previewPane);
-      if (this.showPreview) {
+  },
+  checkPreview() {
+    this.hideIfCurrentEmailRemoved();
+
+    const selectedEmail = document.querySelector(`${EMAIL_CONTAINER}[role="main"]  ${EMAIL_ROW}.btb`);
+    if (selectedEmail) {
+      const previewPane = this.getPreviewPane(selectedEmail);
+      const selectedEmailIsBundled = selectedEmail && selectedEmail.getAttribute('data-bundled');
+      const currentEmailChanged = this.currentEmail !== selectedEmail;
+      const emailPreviewing = previewPane && previewPane.querySelector('.UG');
+      if (currentEmailChanged) {
+        this.currentEmail = selectedEmail;
+        this.movePreviewPane(selectedEmail, previewPane);
+      }
+
+      if (selectedEmailIsBundled || !this.showPreview || !emailPreviewing) {
+        this.hidePreviewPane(previewPane);
+      } else {
         this.showPreviewPane(previewPane);
       }
-    } else if (!this.previewShowing) {
-      this.hidePreviewPane(previewPane);
     }
   }
 };

--- a/src/js/content/emailUtils.js
+++ b/src/js/content/emailUtils.js
@@ -5,36 +5,7 @@ import {
   NAME_COLORS
 } from './constants';
 
-const getSnoozeDate = snoozeString => {
-  const [, count, interval] = snoozeString.split(' ');
-  const intervals = {
-    day: 1,
-    days: 1,
-    week: 7,
-    weeks: 7,
-    month: 30,
-    months: 30
-  };
-  const date = new Date();
-  if (intervals[interval]) {
-    date.setDate(date.getDate() - (count * intervals[interval]));
-    return date;
-  }
-  // if interval is hours, use today
-  if (interval === 'hours') {
-    return date;
-  }
-};
-
-export const buildDateLabel = (dateString, snoozeString) => {
-  let date;
-  if (snoozeString) {
-    date = getSnoozeDate(snoozeString);
-  }
-  if (!date && dateString) {
-    date = new Date(dateString);
-  }
-
+export const buildDateLabel = date => {
   const now = new Date();
   if (!date) {
     return null;

--- a/src/js/content/leftNav.js
+++ b/src/js/content/leftNav.js
@@ -97,7 +97,7 @@ export default {
     leftNavItems.forEach(item => item.addEventListener('click', this.activateMenuItem));
   },
   activateMenuItem(event) {
-    inbox.replaceBundle();
+    inbox.restoreBundle();
     document.querySelectorAll('.nZ').forEach(el => removeClass(el, 'nZ'));
     addClass(event.currentTarget.parentNode, 'nZ');
   },

--- a/src/js/content/navigation.js
+++ b/src/js/content/navigation.js
@@ -37,13 +37,13 @@ export default {
     this.handleHashChange();
   },
   async handleSearchSubmit() {
-    const searchInput = await observeForElement(document, '.gb_sf');
+    const searchInput = await observeForElement(document, 'header form input');
     searchInput.addEventListener('keydown', event => {
       if (event.code === 'Enter') {
         inbox.restoreBundle();
       }
     });
-    const searchButton = document.querySelector('.gb_Bf');
+    const searchButton = document.querySelector('.gb_Df');
     searchButton.addEventListener('click', inbox.restoreBundle);
   },
   handleHashChange() {

--- a/src/js/content/navigation.js
+++ b/src/js/content/navigation.js
@@ -40,11 +40,11 @@ export default {
     const searchInput = await observeForElement(document, '.gb_sf');
     searchInput.addEventListener('keydown', event => {
       if (event.code === 'Enter') {
-        inbox.replaceBundle();
+        inbox.restoreBundle();
       }
     });
     const searchButton = document.querySelector('.gb_Bf');
-    searchButton.addEventListener('click', inbox.replaceBundle);
+    searchButton.addEventListener('click', inbox.restoreBundle);
   },
   handleHashChange() {
     let { hash } = window.location;

--- a/src/js/content/options.js
+++ b/src/js/content/options.js
@@ -24,7 +24,7 @@ export const reloadOptions = () => {
   } else if (options.emailBundling === 'disabled') {
     removeClass(document.body, CLASSES.BUNDLING_OPTION_CLASS);
     // Unbundle emails
-    document.querySelectorAll('[data-bundled="true"]').forEach(emailEl => emailEl.removeAttribute('data-bundled'));
+    document.querySelectorAll('[data-inbox="bundled"]').forEach(emailEl => emailEl.setAttribute('data-inbox', 'email'));
     // Remove bundle wrapper rows
     document.querySelectorAll(`.${CLASSES.BUNDLE_WRAPPER_CLASS}`).forEach(bundleEl => bundleEl.remove());
   }

--- a/src/js/content/utils.js
+++ b/src/js/content/utils.js
@@ -76,7 +76,7 @@ export const openBundle = bundleId => { window.location.href = `#search/in%3Ainb
 export const openInbox = () => { window.location.href = '#inbox'; };
 
 export const getMyEmailAddress = () => {
-  if (document.querySelector('.gb_tb') && document.querySelector('.gb_tb').innerText) {
-    return document.querySelector('.gb_tb').innerText;
+  if (document.querySelector('.gb_vb') && document.querySelector('.gb_vb').innerText) {
+    return document.querySelector('.gb_vb').innerText;
   }
 };

--- a/src/js/content/utils.js
+++ b/src/js/content/utils.js
@@ -31,11 +31,17 @@ export const htmlToElements = html => {
 
 export const isTypable = element => {
   const role = element.getAttribute && element.getAttribute('role');
-  return ['INPUT', 'TEXTAREA'].includes(element.tagName) || (role === 'textbox');
+  return [ 'INPUT', 'TEXTAREA' ].includes(element.tagName) || (role === 'textbox');
 };
 
-// export const pixelsToInt = pixels => (typeof pixels === 'number' ? pixels : parseInt(pixels.replace('px')));
-// export const addPixels = (pixel1, pixel2) => `${pixelsToInt(pixel1) + pixelsToInt(pixel2)}px`;
+export const pixelsToInt = pixels => (typeof pixels === 'number' ? pixels : parseInt(pixels.replace('px')));
+export const addPixels = (...pixels) => {
+  const pixelInt = pixels.reduce((pixel, pixelSum) => {
+    pixelSum += pixelsToInt(pixel);
+    return pixelSum;
+  }, 0);
+  return `${pixelInt}px`;
+};
 
 export const queryParentSelector = (el, selector) => {
   if (!el) {
@@ -70,9 +76,9 @@ export const removeClass = (element, className) => {
 export const getTabs = () => Array.from(document.querySelectorAll('.aKz')).map(el => el.innerText);
 export const isInInbox = () => document.querySelector('.nZ a[title=Inbox]') !== null;
 export const isInBundle = () => document.location.hash.match(/#search\/in%3Ainbox\+label%3A/g) !== null;
-export const getCurrentBundle = () => document.location.hash.replace('#search/in%3Ainbox+label%3A', '');
+export const getCurrentBundle = () => document.location.hash.replace('#search/in%3Ainbox+label%3A', '').replace('+-in%3Astarred', '');
 export const checkImportantMarkers = () => document.querySelector(`${SELECTORS.EMAIL_ROW}:not(.${CLASSES.BUNDLE_WRAPPER_CLASS}) td.WA.xY`);
-export const openBundle = bundleId => { window.location.href = `#search/in%3Ainbox+label%3A${bundleId}`; };
+export const openBundle = bundleId => { window.location.href = `#search/in%3Ainbox+label%3A${bundleId}+-in%3Astarred`; };
 export const openInbox = () => { window.location.href = '#inbox'; };
 
 export const getMyEmailAddress = () => {

--- a/src/js/content/utils.js
+++ b/src/js/content/utils.js
@@ -1,21 +1,27 @@
-import { CLASSES } from './constants';
+import { CLASSES, SELECTORS } from './constants';
 
 // ---- HTML Elements ---- \\
 export const observeForCondition = (el, condition) => new Promise(
   resolve => {
+    let satisfied = condition();
+    if (satisfied) {
+      resolve(satisfied);
+    }
     const observer = new MutationObserver(() => {
-      const satisified = condition();
-      if (satisified) {
+      satisfied = condition();
+      if (satisfied) {
         observer.disconnect();
-        resolve(satisified);
+        resolve(satisfied);
       }
     });
-    observer.observe(el, { subtree: true, childList: true });
+    if (el) {
+      observer.observe(el, { subtree: true, childList: true });
+    }
   }
 );
 
-export const observeForElement = (el, selector) => observeForCondition(el, () => el.querySelector(selector));
-export const observeForRemoval = (el, selector) => observeForCondition(el, () => !el.querySelector(selector));
+export const observeForElement = (el, selector) => observeForCondition(el, () => el && el.querySelector(selector));
+export const observeForRemoval = (el, selector) => observeForCondition(el, () => !el || !el.querySelector(selector));
 
 export const htmlToElements = html => {
   const template = document.createElement('template');
@@ -28,7 +34,8 @@ export const isTypable = element => {
   return ['INPUT', 'TEXTAREA'].includes(element.tagName) || (role === 'textbox');
 };
 
-// export const pixelsToInt = pixels => parseInt(pixels.replace('px'));
+// export const pixelsToInt = pixels => (typeof pixels === 'number' ? pixels : parseInt(pixels.replace('px')));
+// export const addPixels = (pixel1, pixel2) => `${pixelsToInt(pixel1) + pixelsToInt(pixel2)}px`;
 
 export const queryParentSelector = (el, selector) => {
   if (!el) {
@@ -64,7 +71,7 @@ export const getTabs = () => Array.from(document.querySelectorAll('.aKz')).map(e
 export const isInInbox = () => document.querySelector('.nZ a[title=Inbox]') !== null;
 export const isInBundle = () => document.location.hash.match(/#search\/in%3Ainbox\+label%3A/g) !== null;
 export const getCurrentBundle = () => document.location.hash.replace('#search/in%3Ainbox+label%3A', '');
-export const checkImportantMarkers = () => document.querySelector(`.zA:not(.${CLASSES.BUNDLE_WRAPPER_CLASS}) td.WA.xY`);
+export const checkImportantMarkers = () => document.querySelector(`${SELECTORS.EMAIL_ROW}:not(.${CLASSES.BUNDLE_WRAPPER_CLASS}) td.WA.xY`);
 export const openBundle = bundleId => { window.location.href = `#search/in%3Ainbox+label%3A${bundleId}`; };
 export const openInbox = () => { window.location.href = '#inbox'; };
 

--- a/src/scss/bundle.scss
+++ b/src/scss/bundle.scss
@@ -37,26 +37,28 @@
 }
 
 /* Colored bundle titles for Inbox categories */
-.zA.yO[bundleLabel="Updates"]ß .label-link > span:not(.bundle-count) {
-	color: rgb(255, 104, 57);
-}
-.zA.yO[bundleLabel="Promotions"] .label-link > span:not(.bundle-count) {
-	color: rgb(0, 188, 212);
-}
-.zA.yO[bundleLabel="Forums"] .label-link > span:not(.bundle-count) {
-	color: rgb(63, 81, 181);
-}
-.zA.yO[bundleLabel="Social"] .label-link > span:not(.bundle-count) {
-	color: rgb(219, 68, 55);
-}
-.zA.yO[bundleLabel="Travel"] .label-link > span:not(.bundle-count),
-.zA.yO[bundleLabel="Trips"] .label-link > span:not(.bundle-count) {
-	color: rgb(156, 39, 176);
-}
-.zA.yO[bundleLabel="Finance"] .label-link > span:not(.bundle-count) {
-	color: rgb(103, 159, 56);
-}
-.zA.yO[bundleLabel="Orders"] .label-link > span:not(.bundle-count),
-.zA.yO[bundleLabel="Purchases"] .label-link > span:not(.bundle-count) {
-	color: rgb(121, 85, 72);
+.zA.yO {
+	&[bundleLabel="Updates"] .label-link > span:not(.bundle-count) {
+		color: rgb(255, 104, 57);
+	}
+	&[bundleLabel="Promotions"] .label-link > span:not(.bundle-count) {
+		color: rgb(0, 188, 212);
+	}
+	&[bundleLabel="Forums"] .label-link > span:not(.bundle-count) {
+		color: rgb(63, 81, 181);
+	}
+	&[bundleLabel="Social"] .label-link > span:not(.bundle-count) {
+		color: rgb(219, 68, 55);
+	}
+	&[bundleLabel="Travel"] .label-link > span:not(.bundle-count),
+	&[bundleLabel="Trips"] .label-link > span:not(.bundle-count) {
+		color: rgb(156, 39, 176);
+	}
+	&[bundleLabel="Finance"] .label-link > span:not(.bundle-count) {
+		color: rgb(103, 159, 56);
+	}
+	&[bundleLabel="Orders"] .label-link > span:not(.bundle-count),
+	&[bundleLabel="Purchases"] .label-link > span:not(.bundle-count) {
+		color: rgb(121, 85, 72);
+	}
 }

--- a/src/scss/content.scss
+++ b/src/scss/content.scss
@@ -80,7 +80,7 @@
 					background-image: url('chrome-extension://__MSG_@@extension_id__/images/ic_zero_inbox_2x.png');
 					background-repeat: no-repeat;
 					background-position: center;
-					height: calc(100vh - 195px);
+					height: calc(100vh - 200px);
 					// width: 456px;
 					color: transparent;
 					// font-size: 14px;

--- a/src/scss/content.scss
+++ b/src/scss/content.scss
@@ -4,7 +4,7 @@
 
 @import 'email-list';
 @import 'email-list-skinny';
-@import 'email-open';
+@import 'email';
 
 @import 'floating-buttons';
 @import 'header';

--- a/src/scss/email-list.scss
+++ b/src/scss/email-list.scss
@@ -1,208 +1,86 @@
 @import 'email-list-images';
 
-.ae4 { //email-list-container
-	margin-bottom: 40px;
-	.Cp { //email-table-container
-		padding: 0 1px;
-
-		.F.cf.zt tbody { //email-list-table-body
-			.zA.tr:first-child {
-				// add margin so screen doesn't jump while we're figuring out time-rows
-				margin-top: 23px;
+.AO { //main-center-container
+	overflow-y: scroll;
+	padding-right: 12px;
+	&::-webkit-scrollbar {
+		width: 10px;
+	}
+	&::-webkit-scrollbar-button {
+		width: 0;
+		height: 0;
+		display: none;
+	}
+	&::-webkit-scrollbar-corner {
+		background-color: transparent;
+	}
+	&::-webkit-scrollbar-thumb {
+		background-color: rgba(0,0,0,0.2);
+		box-shadow: inset 1px 1px 0 rgba(0,0,0,0.10), inset 0 -1px 0 rgba(0,0,0,0.07);
+	}
+	.BltHke.nH.oy8Mbf { //main-email-container
+		&[data-navigating]::after {
+			content: '';
+			height: 100%;
+			width: 100%;
+			background: #F2F2F2;
+			position: absolute;
+			padding-top: 10px;
+			z-index: 3;
+		}
+	
+		&[data-navigating]::before {
+			content: '';
+			box-sizing: border-box;
+			position: absolute;
+			top: 50%;
+			left: 50%;
+			width: 40px;
+			height: 40px;
+			margin-top: -20px;
+			margin-left: -20px;
+			border-radius: 50%;
+			border: 2px solid #fff;
+			border-top-color: #333;
+			animation: spinner .8s linear infinite;
+			z-index: 4;
+		}
+		&[data-pane="bundle"] {
+			padding: 0 16px;
+			height: auto;
+			background-color: lightgray;
+			width: calc(100% - 44px);
+			margin-top: 50px;
+	
+			.Nt { //bottom-border
+				display: none;
 			}
-
-			.time {
-				color: #666;
-				font-size: 13px;
-				padding-top: 16px;
-				padding-left: 4px;
-				padding-bottom: 8px;
-			}
-			.time-row:first-child .time {
-				padding-top: 0;
-			}
-
-			.zA, .zA:hover { //email-rows, bundle-rows
-				box-shadow: 0 -1px 0 #e0e0e0, 0 0 2px rgba(0,0,0,.12), 0 2px 4px rgba(0,0,0,.24);
-				-webkit-box-shadow: 0 -1px 0 #e0e0e0, 0 0 2px rgba(0,0,0,.12), 0 2px 4px rgba(0,0,0,.24);
-				z-index: inherit;
-				background: #FFF;
-			}
-			.zA { //email-rows, bundle-rows
-				padding: 12px 10px;
-				&:hover .avatar {
+			.email-bundling-enabled & {
+				.yi { //label-indicator-container
 					display: none;
 				}
-				* {
-					font-size: 13px;
-				}
+			}
+		}
+		.Nr.UI.Nf.vy { //another-email-container
+			overflow-y: initial;
+			.Nu.tf.aZ6 { //default-scroll-container
+				overflow-y: initial;
 
-				.oZ-x3 { //checkbox-column
-					&:before { //drag-indicator
-						display: none;
-					}
-					.T-Jo { //checkbox
-						margin-left: 1px;
-						&.T-Jo-Jp.J-J5-Ji { //checkbox-checked
-							display: inline;
-							+ .avatar {
-								display: none;
-							}
+				.ae4 { //email-list-container
+					margin-bottom: 40px;
+					.Cp { //email-table-container
+						padding: 0 1px;
+
+						.F.cf.zt tbody { //email-list-table-body
+							@import 'partials/email-row';
 						}
-					}
-				}
-
-				.WA { //important-indicator-column
-					padding: 0;
-				}
-
-				.yX { // sender-column
-					padding: 0 15px;
-				}
-
-				.a4W { //subject-column
-					.ar { //inline-label
-						height: 22px;
-						border-radius: 2px;
-						.av { //inline-label-text
-							padding-top: 2px;
-						}
-					}
-				}
-
-				.byZ { //snoozed-until-column
-					.cL { //snoozed-until-text
-						font-weight: normal;
-					}
-				}
-
-				.bq4 { //action-buttons-column
-					.bqY { //action-buttons-list
-
-						//make room for the pin
-						position: relative;
-						left: -10px;
-						.bqX { //action-button-item
-							margin: 0 10px;
-
-							&.bru { //delete-button
-								order: 2;
-							}
-							&.brq { //done-button
-								order: 3;
-								// make space for the pin button
-								margin-right: 22px;
-							}
-						}
-					}
-				}
-
-				.apU { //pin-star-column
-					display: block;
-					position: absolute;
-					right: 0px;
-					margin-right: 2px;
-					.aXw { //pin-icon
-						display: none;
-					}
-				}
-
-				.yf { //attachment-column
-					img {
-						display: none;
-					}
-				}
-
-				//this is also holding the list of senders in a bundle
-				.xW { //date-column
-					//make room for the pin icon
-					margin-left: -32px;
-					margin-right: 10px;
-				}
-
-				.show-avatar-enabled & { //option on the body
-					.oZ-x3 { //checkbox-column
-						.T-Jo { //checkbox
-							display: none;
-						}
-					}
-				}
-				&[data-bundled="true"] {
-					display: none;
-				}
-
-				&.aqw { // row-hovered
-					.oZ-x3 { //checkbox-column
-						.T-Jo { //checkbox
-							display: inline;
-						}
-					}
-					.apU { //pin-star-column
-						.aXw { //pin-icon
-							display: flex;
-						}
-					}
-				}
-
-				&.btb { //keyboard-selected-email
-					padding-left: 5px;
-					.PF.xY.PE { //keyboard-focus-indicator
-						//keeps the avatar aligned
-						margin-left: -5px;
-						margin-right: 10px;
 					}
 				}
 			}
 		}
-
-		.BltHke.nH.oy8Mbf { //main-email-container
-			&.nested-bundle {
-				padding-left: 16px;
-				height: auto;
-				background-color: lightgray;
-
-				.Nt { //bottom-border
-					display: none;
-				}
-				.email-bundling-enabled & {
-					.yi { //label-indicator-container
-						display: none;
-					}
-				}
-			}
-		}
-	}
-}
-
-.BltHke.nH.oy8Mbf { //main-email-container
-	&[data-navigating]::after {
-		content: '';
-		height: 100%;
-		width: 100%;
-		background: #F2F2F2;
-		position: absolute;
-		padding-top: 10px;
-		z-index: 3;
-	}
-
-	&[data-navigating]::before {
-		content: '';
-		box-sizing: border-box;
-		position: absolute;
-		top: 50%;
-		left: 50%;
-		width: 40px;
-		height: 40px;
-		margin-top: -20px;
-		margin-left: -20px;
-		border-radius: 50%;
-		border: 2px solid #fff;
-		border-top-color: #333;
-		animation: spinner .8s linear infinite;
-		z-index: 4;
 	}
 }
 
 @keyframes spinner {
-  to {transform: rotate(360deg);}
+  to { transform: rotate(360deg); }
 }

--- a/src/scss/email-list.scss
+++ b/src/scss/email-list.scss
@@ -1,30 +1,12 @@
 @import 'email-list-images';
 
-.Nu.S3.aZ6 { //preview-pane
-	overflow: auto;
-	box-shadow: 0 3px 4px rgba(0,0,0,.24);
-
-	&:not(.show-preview) {
-		//need !important to override inline styles
-		flex-grow: 0 !important;
-		height: 0 !important;
-	}
-	.if > .byY { //email subject header
-		padding-left: 20px;
-	}
-
-	.ii.gt { //email-body
-		padding-right: 56px;
-	}
-}
-
 .ae4 { //email-list-container
 	margin-bottom: 40px;
 	.Cp { //email-table-container
 		padding: 0 1px;
 
 		.F.cf.zt tbody { //email-list-table-body
-			tr:first-child {
+			.zA.tr:first-child {
 				// add margin so screen doesn't jump while we're figuring out time-rows
 				margin-top: 23px;
 			}
@@ -148,12 +130,6 @@
 				&[data-bundled="true"] {
 					display: none;
 				}
-				.email-bundling-enabled.bundle-page & {
-					.yi { //label-indicator-container
-						display: none;
-					}
-				}
-
 
 				&.aqw { // row-hovered
 					.oZ-x3 { //checkbox-column
@@ -181,12 +157,17 @@
 
 		.BltHke.nH.oy8Mbf { //main-email-container
 			&.nested-bundle {
-				padding: 0 20px;
+				padding-left: 16px;
 				height: auto;
 				background-color: lightgray;
 
 				.Nt { //bottom-border
 					display: none;
+				}
+				.email-bundling-enabled & {
+					.yi { //label-indicator-container
+						display: none;
+					}
 				}
 			}
 		}

--- a/src/scss/email-open.scss
+++ b/src/scss/email-open.scss
@@ -1,3 +1,31 @@
+.Nu.S3.aZ6 { //preview-pane
+	overflow: auto;
+	box-shadow: 0 3px 4px rgba(0,0,0,.24);
+
+	&:not(.show-preview) {
+		//need !important to override inline styles
+		flex-grow: 0 !important;
+		height: 0 !important;
+	}
+	&.show-preview {
+		margin-bottom: 10px;
+		// width: calc(100% - 17px);
+	}
+	.if > .byY { //email-subject-header
+		padding-left: 20px;
+	}
+
+	.ii.gt { //email-body
+		padding-right: 56px;
+	}
+
+	.nH.if { //email-container
+		.nH.eE0 { //bottom-spacer
+			padding-bottom: !important;
+		}
+	}
+}
+
 .Bs.nH.iY.bAt { //email-container
 	margin: 2px;
 	box-shadow: 0 -1px 0 #e0e0e0, 0 0 2px rgba(0,0,0,.12), 0 2px 4px rgba(0,0,0,.24);

--- a/src/scss/email-open.scss
+++ b/src/scss/email-open.scss
@@ -20,8 +20,8 @@
 	}
 
 	.nH.if { //email-container
-		.nH.eE0 { //bottom-spacer
-			padding-bottom: !important;
+		.nH.aE0 { //bottom-spacer
+			padding-bottom: 0 !important;
 		}
 	}
 }

--- a/src/scss/email.scss
+++ b/src/scss/email.scss
@@ -1,6 +1,7 @@
 .Nu.S3.aZ6 { //preview-pane
 	overflow: auto;
 	box-shadow: 0 3px 4px rgba(0,0,0,.24);
+	width: calc(100% - 1px);
 
 	&:not(.show-preview) {
 		//need !important to override inline styles
@@ -9,7 +10,6 @@
 	}
 	&.show-preview {
 		margin-bottom: 10px;
-		// width: calc(100% - 17px);
 	}
 	.if > .byY { //email-subject-header
 		padding-left: 20px;
@@ -47,7 +47,7 @@
 				}
 			}
 		}
-		.ii.gt {	//email-body
+		.ii.gt { //email-body
 			padding-right: 56px;
 		}
 	}

--- a/src/scss/left-nav.scss
+++ b/src/scss/left-nav.scss
@@ -1,8 +1,12 @@
 @import 'left-nav-images';
 .aeN { //left-sidebar
   &.bhZ { //collapsed
-    transform: translateX(-80px) !important;
-    transition: transform 0.2s ease;
+    // below will hide the collapsed left-hand nav entirel
+    // transform: translateX(-80px) !important;
+    // transition: transform 0.2s ease;
+    &.bym { //small-nav-container
+  		background: #F2F2F2;
+    }
   }
 
   .ajl.aib .wT { //left-container

--- a/src/scss/partials/_email-row.scss
+++ b/src/scss/partials/_email-row.scss
@@ -1,0 +1,145 @@
+.time {
+    color: #666;
+    font-size: 13px;
+    padding-top: 16px;
+    padding-left: 4px;
+    padding-bottom: 8px;
+}
+.time-row:first-child .time {
+    padding-top: 0;
+}
+
+.zA, .zA:hover { //email-rows, bundle-rows
+    box-shadow: 0 -1px 0 #e0e0e0, 0 0 2px rgba(0,0,0,.12), 0 2px 4px rgba(0,0,0,.24);
+    -webkit-box-shadow: 0 -1px 0 #e0e0e0, 0 0 2px rgba(0,0,0,.12), 0 2px 4px rgba(0,0,0,.24);
+    z-index: inherit;
+    background: #FFF;
+}
+.zA { //email-rows, bundle-rows
+    padding: 12px 10px;
+    &.tr:first-child {
+        // add margin so screen doesn't jump while we're figuring out time-rows
+        margin-top: 23px;
+    }
+    &:hover .avatar {
+        display: none;
+    }
+    * {
+        font-size: 13px;
+    }
+    .oZ-x3 { //checkbox-column
+        &:before { //drag-indicator
+            display: none;
+        }
+        .T-Jo { //checkbox
+            margin-left: 1px;
+            &.T-Jo-Jp.J-J5-Ji { //checkbox-checked
+                display: inline;
+                + .avatar {
+                    display: none;
+                }
+            }
+        }
+    }
+
+    .WA { //important-indicator-column
+        padding: 0;
+    }
+
+    .yX { // sender-column
+        padding: 0 15px;
+    }
+
+    .a4W { //subject-column
+        .ar { //inline-label
+            height: 22px;
+            border-radius: 2px;
+            .av { //inline-label-text
+                padding-top: 2px;
+            }
+        }
+    }
+
+    .byZ { //snoozed-until-column
+        .cL { //snoozed-until-text
+            font-weight: normal;
+        }
+    }
+
+    .bq4 { //action-buttons-column
+        .bqY { //action-buttons-list
+
+            //make room for the pin
+            position: relative;
+            left: -10px;
+            .bqX { //action-button-item
+                margin: 0 10px;
+
+                &.bru { //delete-button
+                    order: 2;
+                }
+                &.brq { //done-button
+                    order: 3;
+                    // make space for the pin button
+                    margin-right: 22px;
+                }
+            }
+        }
+    }
+
+    .apU { //pin-star-column
+        display: block;
+        position: absolute;
+        right: 0px;
+        margin-right: 2px;
+        .aXw { //pin-icon
+            display: none;
+        }
+    }
+
+    .yf { //attachment-column
+        img {
+            display: none;
+        }
+    }
+
+    //this is also holding the list of senders in a bundle
+    .xW { //date-column
+        //make room for the pin icon
+        margin-left: -32px;
+        margin-right: 10px;
+    }
+
+    .show-avatar-enabled & { //option on the body
+        .oZ-x3 { //checkbox-column
+            .T-Jo { //checkbox
+                display: none;
+            }
+        }
+    }
+    &[data-inbox="bundled"] {
+        display: none;
+    }
+
+    &.aqw { // row-hovered
+        .oZ-x3 { //checkbox-column
+            .T-Jo { //checkbox
+                display: inline;
+            }
+        }
+        .apU { //pin-star-column
+            .aXw { //pin-icon
+                display: flex;
+            }
+        }
+    }
+
+    &.btb { //keyboard-selected-email
+        padding-left: 5px;
+        .PF.xY.PE { //keyboard-focus-indicator
+            //keeps the avatar aligned
+            margin-left: -5px;
+            margin-right: 10px;
+        }
+    }
+}


### PR DESCRIPTION
## [#37] use spacers and absolute positioning for preview and bundle displays
* always hide preview pane when clicking a bundle row
* simplify/clarify the logic for checking if the preview should shown/hidden
* hide preview if no email is showing; fixes marking an email unread and empty preview showing
* now that bundles aren't inside the inbox's element, simplify preview pane selection
* add a preview-placeholder next to the selected email and have it's height match that of the selected email's
* absolute position the preview pane to be where the placeholder is
* remove logic that 'saves' the preview, shouldn't be necessary since we're not moving it anymore
* refactor 'moving' the bundle element to match the preview concepts - use a placeholder and then absolute position the bundle element at it
* move scrolling to an outer container so the whole inbox scrolls as one;
**also eliminates funky jumping gmail does when selecting an email
resolves #37

### Bundles
* always reprocess bundle data for emails, if it's been starred, it might need to be moved in/out of a bundle
* make sure nested bundles are marked as such before processing emails
* don't process inbox emails when in a nested bundle
* rename replaceBundle to restoreBundle for clarity

### Refactor data attributes and classes
* rows in the inbox now have the data-inbox attribute, which can have the following values
** email - visible emails
** bundled - emails in a bundle that are hidden
** bundle ID - bundle rows
* main email containers now use data-pane instead of data-inbox and .nested-bundle
* email rows no longer have data-bundle or data-nested-email

## [#38] re-click the element when clicking an email row outside of a bundle
* When clicking an email with a bundle open, wait for the bundle to disappear and then try to re-click the originally clicked element
resolves #38

## Minor Updates
* update default bundle color check
* update isStarred check to use classes
* removed inline styles that hide emails, doesn't seem to be needed anymore
* go back to using the previous date for snoozed emails
* hide the preview if the thread ID for the preview pane and the selected email don't match
** happens when archiving emails from the oldest to the newest and gmail doesn't automatically swap the previewing email
* fix some selectors for search elements in the header
* exclude starred emails when loading a bundle
* split email-rows out into a partial scss file
* check condition and resolve observeForCondition immediately if it's already satisfied
* create a SELECTORS constant and add email container, email row, and preview pane to it
** update uses of those selectors to the constants
* utility functions for handling heights
* show the small menu when collapsed
