### PR TITLE
[#37] more tweaks to smooth preview email

### DIFF
--- a/src/js/content/dateLabels.js
+++ b/src/js/content/dateLabels.js
@@ -38,9 +38,12 @@ export default {
     email.parentElement.insertBefore(timeRow, email);
   },
   isEmptyDateLabel(row) {
-    const sibling = row.nextSibling;
+    let sibling = row.nextSibling;
     if (!sibling) {
       return true;
+    }
+    if (sibling.classList.contains('bundle-placeholder')) {
+      sibling = sibling.nextSibling;
     }
     if (sibling.className === 'time-row') {
       return true;

--- a/src/js/content/inbox.js
+++ b/src/js/content/inbox.js
@@ -161,7 +161,7 @@ export default {
       }
       const bundlePlaceholder = document.querySelector('.bundle-placeholder');
       if (bundlePlaceholder) {
-        bundlePlaceholder.style.height = 0;
+        bundlePlaceholder.remove();
       }
     }
   },

--- a/src/js/content/utils.js
+++ b/src/js/content/utils.js
@@ -76,7 +76,10 @@ export const removeClass = (element, className) => {
 export const getTabs = () => Array.from(document.querySelectorAll('.aKz')).map(el => el.innerText);
 export const isInInbox = () => document.querySelector('.nZ a[title=Inbox]') !== null;
 export const isInBundle = () => document.location.hash.match(/#search\/in%3Ainbox\+label%3A/g) !== null;
-export const getCurrentBundle = () => document.location.hash.replace('#search/in%3Ainbox+label%3A', '').replace('+-in%3Astarred', '');
+export const getCurrentBundle = () => {
+  const matches = document.location.hash.match(/#search\/in%3Ainbox\+label%3A(.*)\+-in%3Astarred/);
+  return matches && matches[1];
+};
 export const checkImportantMarkers = () => document.querySelector(`${SELECTORS.EMAIL_ROW}:not(.${CLASSES.BUNDLE_WRAPPER_CLASS}) td.WA.xY`);
 export const openBundle = bundleId => { window.location.href = `#search/in%3Ainbox+label%3A${bundleId}+-in%3Astarred`; };
 export const openInbox = () => { window.location.href = '#inbox'; };

--- a/src/scss/email.scss
+++ b/src/scss/email.scss
@@ -11,6 +11,9 @@
 	&.show-preview {
 		margin-bottom: 10px;
 	}
+	.ao8 { //preview-pain-container
+		width: auto !important;
+	}
 	.if > .byY { //email-subject-header
 		padding-left: 20px;
 	}

--- a/src/scss/partials/_email-row.scss
+++ b/src/scss/partials/_email-row.scss
@@ -135,7 +135,14 @@
     }
 
     &.btb { //keyboard-selected-email
-        padding-left: 5px;
+        padding-left: 4px;
+        &[data-previewing] {
+            position: sticky;
+            top: 0;
+            z-index: 1;
+            box-shadow: 0 -1px 0 #e0e0e0, 0 0 2px rgba(0,0,0,.12);
+        }
+
         .PF.xY.PE { //keyboard-focus-indicator
             //keeps the avatar aligned
             margin-left: -5px;


### PR DESCRIPTION
## [#37]
* track the email row that has the preview pane with data-previewing attribute and make it stick
* use padding on the preview pane so it scrolls correctly (eliminates need for additional height on the placeholder)

## Minor Updates
* ignore bundle-placeholders when checking date labels
* remove the bundle-placeholder when closed also to help make date labels work better
* use regex (@jahan-addison would be proud) to capture the current bundle from the URL
* force width on preview-pane-container so it expands without jumping