### PR TITLE
[#24] reminder styles and more

### DIFF
--- a/src/js/content/calendar.js
+++ b/src/js/content/calendar.js
@@ -1,5 +1,5 @@
 import { CLASSES } from './constants';
-import { htmlToElements } from './utils';
+import { htmlToElements, querySelectorText } from './utils';
 
 export default {
   addEventAttachment(email) {
@@ -9,14 +9,11 @@ export default {
 
     let title = 'Calendar Event';
     let time = '';
-    const titleNode = email.querySelector('.bqe, .bog');
-    if (titleNode) {
-      const titleFullText = titleNode.innerText;
-      const matches = Array.from(titleFullText.matchAll(/[^:]*: ([^@]*)@(.*)/g))[0];
-      if (matches) {
-        title = matches[1].trim();
-        time = matches[2].trim();
-      }
+    const titleFullText = querySelectorText('.bqe, .bog', email);
+    const matches = Array.from(titleFullText.matchAll(/[^:]*: ([^@]*)@(.*)/g))[0];
+    if (matches) {
+      title = matches[1].trim();
+      time = matches[2].trim();
     }
 
     const calendarNode = htmlToElements(`

--- a/src/js/content/dateLabels.js
+++ b/src/js/content/dateLabels.js
@@ -42,8 +42,11 @@ export default {
     if (!sibling) {
       return true;
     }
-    if (sibling.classList.contains('bundle-placeholder')) {
+    if (sibling.classList.contains('bundle-placeholder') || sibling.classList.contains('preview-placeholder')) {
       sibling = sibling.nextSibling;
+    }
+    if (!sibling) {
+      return true;
     }
     if (sibling.className === 'time-row') {
       return true;

--- a/src/js/content/inbox.js
+++ b/src/js/content/inbox.js
@@ -28,10 +28,12 @@ export default {
         let inbox = document.querySelector(`${EMAIL_CONTAINER}[role=main][data-pane="inbox"]`);
         if (!inbox) {
           inbox = document.querySelector(`${EMAIL_CONTAINER}[role=main]`);
-          inbox.setAttribute('data-pane', 'inbox');
-          const previewPane = inbox.querySelector(PREVIEW_PANE);
-          if (previewPane) {
-            previewPane.setAttribute('data-pane', 'inbox');
+          if (inbox) {
+            inbox.setAttribute('data-pane', 'inbox');
+            const previewPane = inbox.querySelector(PREVIEW_PANE);
+            if (previewPane) {
+              previewPane.setAttribute('data-pane', 'inbox');
+            }
           }
         }
       }
@@ -142,9 +144,10 @@ export default {
           }
           bundlePane.style.position = 'absolute';
           bundleRow.parentNode.insertBefore(bundlePlaceholder, bundleRow.nextSibling);
-          bundlePane.style.top = addPixels(bundleRow.offsetTop, bundleRow.clientHeight);
+          bundlePane.style.top = addPixels(bundleRow.offsetTop, bundleRow.clientHeight, 6);
 
           const adjustBundleHeight = () => {
+            bundlePane.style['margin-top'] = `${bundleRow.clientHeight}px`;
             bundlePlaceholder.style.height = `${bundlePane.offsetHeight}px`;
           };
           if (this.bundleObserver) {

--- a/src/js/content/navigation.js
+++ b/src/js/content/navigation.js
@@ -96,10 +96,12 @@ export default {
     composeButton.click();
 
     // TODO: Delete waitForElement() function, replace with gmail.observe.on('compose') via the Gmail.js lib
-    const to = await observeForElement(document, 'textarea[name=to]');
-    const title = document.querySelector('input[name=subjectbox]');
-    const body = document.querySelector('div[aria-label="Message Body"]');
-    const from = document.querySelector('input[name="from"]');
+    const composeContainer = await observeForElement(document, '.AD');
+    addClass(composeContainer, 'compose-reminder');
+    const to = composeContainer.querySelector('textarea[name=to]');
+    const title = composeContainer.querySelector('input[name=subjectbox]');
+    const body = composeContainer.querySelector('div[aria-label="Message Body"]');
+    const from = composeContainer.querySelector('input[name="from"]');
 
     from.value = myEmail;
     to.value = myEmail;

--- a/src/js/content/utils.js
+++ b/src/js/content/utils.js
@@ -22,6 +22,20 @@ export const observeForCondition = (el, condition) => new Promise(
 
 export const observeForElement = (el, selector) => observeForCondition(el, () => el && el.querySelector(selector));
 export const observeForRemoval = (el, selector) => observeForCondition(el, () => !el || !el.querySelector(selector));
+export const startObserver = (observer, element, options, callback) => {
+  if (observer) {
+    observer.disconnect();
+  }
+  observer = new MutationObserver(callback);
+  observer.observe(element, options);
+  return observer;
+};
+
+export const querySelectorWithText = (selector, container = document) => {
+  const element = container.querySelector(selector);
+  return element ? { element, text: element.innerText } : {};
+};
+export const querySelectorText = (selector, container = document) => querySelectorWithText(selector, container).text;
 
 export const htmlToElements = html => {
   const template = document.createElement('template');
@@ -74,7 +88,7 @@ export const removeClass = (element, className) => {
 
 // ---- Gmail ---- \\
 export const getTabs = () => Array.from(document.querySelectorAll('.aKz')).map(el => el.innerText);
-export const isInInbox = () => document.querySelector('.nZ a[title=Inbox]') !== null;
+export const isInInbox = () => document.location.hash.match(/#inbox/g) !== null;
 export const isInBundle = () => document.location.hash.match(/#search\/in%3Ainbox\+label%3A/g) !== null;
 export const getCurrentBundle = () => {
   const matches = document.location.hash.match(/#search\/in%3Ainbox\+label%3A(.*)\+-in%3Astarred/);

--- a/src/scss/content.scss
+++ b/src/scss/content.scss
@@ -5,6 +5,7 @@
 @import 'email-list';
 @import 'email-list-skinny';
 @import 'email';
+@import 'reminder';
 
 @import 'floating-buttons';
 @import 'header';

--- a/src/scss/email-list.scss
+++ b/src/scss/email-list.scss
@@ -2,7 +2,6 @@
 
 .AO { //main-center-container
 	overflow-y: scroll;
-	padding-right: 12px;
 	&::-webkit-scrollbar {
 		width: 10px;
 	}
@@ -49,8 +48,9 @@
 			padding: 0 16px;
 			height: auto;
 			background-color: lightgray;
-			width: calc(100% - 44px);
-			margin-top: 50px;
+			width: calc(100% - 34px);
+			margin-left: 1px;
+			z-index: 1;
 	
 			.Nt { //bottom-border
 				display: none;

--- a/src/scss/email.scss
+++ b/src/scss/email.scss
@@ -8,9 +8,6 @@
 		flex-grow: 0 !important;
 		height: 0 !important;
 	}
-	&.show-preview {
-		margin-bottom: 10px;
-	}
 	.ao8 { //preview-pain-container
 		width: auto !important;
 	}

--- a/src/scss/reminder.scss
+++ b/src/scss/reminder.scss
@@ -1,0 +1,27 @@
+.AD [role="dialog"] {
+    top: 50px;
+}
+
+.AD.compose-reminder {
+    top: calc(50vh - 150px);
+    left: calc(50vw - 400px);
+    position: fixed !important;
+    width: 800px;
+
+    .iN > tbody > tr:first-child, // compose-email-body
+    .aDl, // compose-email-body-formatting-options
+    .hl, // compose-email-to
+    .btC td:not(.Up), // compose-email-footer-row (hides all but the 'Send' Button)
+    .hG // compose-email-send-more-options
+    {
+        display: none !important;
+    }
+
+    tr.btC { //compose-email-footer-row
+        justify-content: flex-end;
+    }
+
+    .aoO { // compose-email-send-button
+        border-radius: 4px !important;
+    }
+}


### PR DESCRIPTION
* add querySelectorText and startObserver helpers
* skip preview placeholder when checking for empty date labels
* treat emails with 'calendar reminders' in their body as reminders, resolves #24
* use this.currentEmail insted of passing a selectedEmail around in emailPreview.js
* check position of the previewPane on any change to the currentEmail
* scroll to the currently email when it's selected
* tweak reminder email display to show the from email in case it's wrong
* change logic for isInInbox to check the current hash
* tweak bundle pane styles to center it better
* add styles for reminder creation