### PR TITLE
[#42] add show bundle emails button

### DIFF
--- a/src/js/content/constants.js
+++ b/src/js/content/constants.js
@@ -1,7 +1,7 @@
-export const MONTHS = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
+export const MONTHS = [ 'January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December' ];
 
-export const NAME_COLORS = ['1bbc9b', '16a086', 'f1c40f', 'f39c11', '2dcc70', '27ae61', 'd93939', 'd25400', '3598db', '297fb8', 'e84c3d', 'c1392b',
-  '9a59b5', '8d44ad', 'bec3c7', '34495e', '2d3e50', '95a5a4', '7e8e8e', 'ec87bf', 'd870ad', 'f69785', '9ba37e', 'b49255', 'b49255', 'a94136'];
+export const NAME_COLORS = [ '1bbc9b', '16a086', 'f1c40f', 'f39c11', '2dcc70', '27ae61', 'd93939', 'd25400', '3598db', '297fb8', 'e84c3d', 'c1392b',
+  '9a59b5', '8d44ad', 'bec3c7', '34495e', '2d3e50', '95a5a4', '7e8e8e', 'ec87bf', 'd870ad', 'f69785', '9ba37e', 'b49255', 'b49255', 'a94136' ];
 
 export const DATE_LABELS = {
   TODAY: 'Today',

--- a/src/js/content/email.js
+++ b/src/js/content/email.js
@@ -8,6 +8,7 @@ import { getOptions } from './options';
 import emailPreview from './emailPreview';
 import {
   addClass,
+  encodeBundleId,
   getMyEmailAddress,
   getTabs,
   querySelectorText,
@@ -52,7 +53,7 @@ export default class Email {
   }
 
   isBundled() {
-    return this.emailEl.getAttribute('data-inbox') === 'bundled';
+    return [ 'bundled', 'show-bundled' ].includes(this.emailEl.getAttribute('data-inbox'));
   }
 
   isReminder() {
@@ -150,7 +151,12 @@ export default class Email {
       const isUnbundled = labels.some(label => label.title.includes(CLASSES.UNBUNDLED_PARENT_LABEL));
 
       if (labels.length && !isStarred && !isUnbundled) {
-        this.emailEl.setAttribute('data-inbox', 'bundled');
+        if (this.emailEl.getAttribute('data-inbox') !== 'show-bundled') {
+          this.emailEl.setAttribute('data-inbox', 'bundled');
+        }
+        labels.forEach(label => {
+          this.emailEl.setAttribute(`data-${encodeBundleId(label.title)}`, true);
+        });
       } else {
         this.emailEl.setAttribute('data-inbox', 'email');
         if (isUnbundled) {

--- a/src/js/content/utils.js
+++ b/src/js/content/utils.js
@@ -57,6 +57,8 @@ export const addPixels = (...pixels) => {
   return `${pixelInt}px`;
 };
 
+export const encodeBundleId = bundleId => encodeURIComponent(bundleId.replace(/[/\\& ]/g, '-'));
+
 export const queryParentSelector = (el, selector) => {
   if (!el) {
     return null;

--- a/src/scss/bundle.scss
+++ b/src/scss/bundle.scss
@@ -31,8 +31,21 @@
 	.bundle-senders span.strong {
 		font-weight: 700;
 	}
+	.bq4 .show-emails {
+		background-image: url('chrome-extension://__MSG_@@extension_id__/images/ic_custom-cluster_24px_g60_r3_2x.png') !important;
+		background-size: contain;
+	}
+
 	&:not(.contains-unread) .bundle-image img {
 		opacity: 0.6;
+	}
+	&:hover {
+		.xW { //date-column
+			display: none;
+		}
+		.bq4 { //action-buttons-column
+			display: flex;
+		}
 	}
 }
 

--- a/src/scss/reminder.scss
+++ b/src/scss/reminder.scss
@@ -10,7 +10,7 @@
 
     .iN > tbody > tr:first-child, // compose-email-body
     .aDl, // compose-email-body-formatting-options
-    .hl, // compose-email-to
+    // .hl, // compose-email-to
     .btC td:not(.Up), // compose-email-footer-row (hides all but the 'Send' Button)
     .hG // compose-email-send-more-options
     {


### PR DESCRIPTION
* resolves #42
* add a button that will show emails from the bundle in the inbox
** useful when an email won't show in the bundle, related to a response coming in on a snoozed email
* unhide the email-to on reminder composes in case it's wrong