### PR TITLE
feat(#46): use profile photos from google if available

### DIFF
--- a/src/js/content/emailUtils.js
+++ b/src/js/content/emailUtils.js
@@ -4,6 +4,7 @@ import {
   MONTHS,
   NAME_COLORS
 } from './constants';
+import profilePhoto from './profilePhoto';
 
 export const buildDateLabel = date => {
   const now = new Date();
@@ -30,22 +31,32 @@ export const buildDateLabel = date => {
   return date.getFullYear().toString();
 };
 
-export const buildAvatar = firstLetter => {
-  const avatarElement = document.createElement('div');
-  avatarElement.className = CLASSES.AVATAR_CLASS;
-  if (firstLetter) {
-    const firstLetterCode = firstLetter.charCodeAt(0);
-
-    if (firstLetterCode >= 65 && firstLetterCode <= 90) {
-      avatarElement.style.background = `#${NAME_COLORS[firstLetterCode - 65]}`;
-    } else {
-      avatarElement.style.background = '#000000';
-      // Some unicode characters are not affected by 'color: white', hence this alternative
-      avatarElement.style.color = 'transparent';
-      avatarElement.style.textShadow = '0 0 rgba(255, 255, 255, 0.65)';
-    }
-
-    avatarElement.innerText = firstLetter;
+export const buildAvatar = (avatarWrapperEl, participant) => {
+  let avatarElement = avatarWrapperEl.querySelector(`.${CLASSES.AVATAR_CLASS}`);
+  if (!avatarElement) {
+    avatarElement = document.createElement('div');
+    avatarElement.className = CLASSES.AVATAR_CLASS;
+    avatarWrapperEl.appendChild(avatarElement);
   }
-  return avatarElement;
+
+  if (participant) {
+    const photoUrl = profilePhoto.getPhotoUrl(participant.email);
+    const firstLetter = (participant && participant.name && participant.name.toUpperCase()[0]) || '-';
+    if (photoUrl) {
+      avatarElement.style.background = `url(${photoUrl})`;
+      avatarElement.innerText = '';
+    } else if (firstLetter) {
+      const firstLetterCode = firstLetter.charCodeAt(0);
+      if (firstLetterCode >= 65 && firstLetterCode <= 90) {
+        avatarElement.style.background = `#${NAME_COLORS[firstLetterCode - 65]}`;
+      } else {
+        avatarElement.style.background = '#000000';
+        // Some unicode characters are not affected by 'color: white', hence this alternative
+        avatarElement.style.color = 'transparent';
+        avatarElement.style.textShadow = '0 0 rgba(255, 255, 255, 0.65)';
+      }
+
+      avatarElement.innerText = firstLetter;
+    }
+  }
 };

--- a/src/js/content/inbox.js
+++ b/src/js/content/inbox.js
@@ -13,6 +13,7 @@ import dateLabels from './dateLabels';
 import { getOptions, reloadOptions } from './options';
 import { CLASSES, SELECTORS } from './constants';
 import emailPreview from './emailPreview';
+import profilePhoto from './profilePhoto';
 
 const { EMAIL_CONTAINER, EMAIL_ROW, PREVIEW_PANE } = SELECTORS;
 const { BUNDLE_WRAPPER_CLASS } = CLASSES;
@@ -53,6 +54,7 @@ export default {
 
     const currentTab = tabs.length && document.querySelector('.aAy[aria-selected="true"]');
     const labelStats = {};
+    const participantEmails = new Set();
     let prevDate;
 
     // Start from last email on page and head towards first
@@ -75,7 +77,7 @@ export default {
 
       // Collect senders, message count and unread stats for each label
       if (emailLabels.length && email.isBundled()) {
-        const firstParticipant = email.getParticipantNames()[0];
+        const firstParticipant = email.isReminder() ? 'Reminder' : email.getParticipants()[0].name;
         emailLabels.forEach(label => {
           if (!labelStats[label]) {
             labelStats[label] = {
@@ -100,7 +102,9 @@ export default {
           }
         });
       }
+      email.getParticipants().forEach(participant => participantEmails.add(participant.email));
     }
+    profilePhoto.fetchProfilePhotos([...participantEmails]);
 
     // Update bundle stats
     if (isInInboxFlag && !isInBundle() && options.emailBundling === 'enabled') {

--- a/src/js/content/profilePhoto.js
+++ b/src/js/content/profilePhoto.js
@@ -1,0 +1,125 @@
+const LOOKUP_PROFILE_URL = 'https://people-pa.clients6.google.com/v2/people/lookup';
+
+const hexString = buffer => {
+  const byteArray = new Uint8Array(buffer);
+  const hexCodes = [...byteArray].map(value => {
+    const hexCode = value.toString(16);
+    const paddedHexCode = hexCode.padStart(2, '0');
+    return paddedHexCode;
+  });
+  return hexCodes.join('');
+};
+
+const sha1 = async message => {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(message);
+  const digestValue = await crypto.subtle.digest('SHA-1', data);
+  return hexString(digestValue);
+};
+
+const appendQueryParams = (url, queryParams) => {
+  Object.keys(queryParams).forEach(key => {
+    if (Array.isArray(queryParams[key])) {
+      queryParams[key].forEach(queryValue => url.searchParams.append(key, queryValue));
+    } else {
+      url.searchParams.append(key, queryParams[key]);
+    }
+  });
+  return url;
+};
+
+const cachedProfiles = [];
+
+const profilePhoto = {
+  getCachedProfile(senderAddress) {
+    return cachedProfiles.find(cached => cached.senderAddress === senderAddress);
+  },
+  getPhotoUrl(senderAddress) {
+    const sender = this.getCachedProfile(senderAddress);
+    if (sender) {
+      return sender.photoURL;
+    }
+  },
+  buildProfileLookupUrl(senderAddressList) {
+    // Query parameters to be attached to LOOKUP_PROFILE_URL
+    const profileLoookupQueryParams = {
+      'context.clientVersion.clientType': 'GMAIL_WEB_DOMAIN',
+      'context.clientVersion.clientVersion': 'contact_store_245761685',
+      id: senderAddressList,
+      'mergedPersonSourceOptions.includedProfileStates': 'CORE_ID',
+      'mergedPersonSourceOptions.personModelParams.personModel': 'CONTACT_CENTRIC',
+      'profileLookupOptions.emailLookupOption': 'INCLUDE_EMAIL_LOOKUP_KEY',
+      'requestMask.includeContainer': [ 'CONTACT', 'PROFILE', 'DOMAIN_CONTACT', 'DOMAIN_PROFILE', 'AFFINITY' ],
+      'requestMask.includeField': 'person.name,person.photo,person.email,person.phone,person.email.certificate,person.metadata',
+      'requestMask.imageUrlType': 'FIFE_URL',
+      type: 'EMAIL',
+      // Surprisingly, this key is static across accounts/browsers. It's hardcoded and seems like it's been around for years.
+      // It's not an important API key, despite the name. The real auth is done in the headers and cookie exchange.
+      key: 'AIzaSyBuUpn1wi2-0JpM3S-tq2csYx0z2_m_pqc',
+      // Appears to be static across different accounts/browsers, despite the name of this property.
+      $unique: 'gc606'
+    };
+
+    return appendQueryParams(new URL(LOOKUP_PROFILE_URL), profileLoookupQueryParams);
+  },
+  async getMatches(senderAddressList) {
+    const pageCookies = document.cookie.split('; ').map(x => ({ name: x.split('=')[0], value: x.split('=')[1] }));
+    const SAPISID = pageCookies.find(x => x.name === 'SAPISID').value;
+    const timestamp = Math.round(new Date().getTime() / 1000);
+    const origin = 'https://mail.google.com';
+    const tokenHash = await sha1(`${timestamp} ${SAPISID} ${origin}`);
+    const authorizationHeader = `SAPISIDHASH ${timestamp}_${tokenHash}`;
+
+    const clientDetails = [ 'appVersion', 'platform', 'userAgent' ];
+    // eslint-disable-next-line camelcase
+    const X_ClientDetails = clientDetails.map(val => `${val}=${encodeURIComponent(navigator[val])}`).join('&');
+    // Get user number from /mail/u/{:number}/
+    // eslint-disable-next-line camelcase
+    const X_Goog_AuthUser = window.location.pathname.split('/')[3];
+
+    const fetchParams = {
+      method: 'GET',
+      headers: {
+        Authorization: authorizationHeader,
+        DNT: '1',
+        Origin: origin,
+        Referer: `https://mail.google.com/mail/u/${X_Goog_AuthUser}/`, // eslint-disable-line camelcase
+        'User-Agent': navigator.userAgent,
+        'X-ClientDetails': X_ClientDetails,
+        'X-Goog-AuthUser': X_Goog_AuthUser,
+        'X-Goog-Encode-Response-If-Executable': 'base64',
+        'X-JavaScript-User-Agent': 'google-api-javascript-client/1.1.0',
+        'X-Requested-With': 'XMLHttpRequest'
+      },
+      mode: 'cors',
+      credentials: 'include',
+      referrerPolicy: 'no-referrer-when-downgrade'
+    };
+
+    const lookupProfileUrl = this.buildProfileLookupUrl(senderAddressList);
+    const response = await fetch(lookupProfileUrl, fetchParams);
+    return response.json();
+  },
+  async fetchProfilePhotos(senderAddressList) {
+    if (!Array.isArray(senderAddressList)) {
+      senderAddressList = [senderAddressList];
+    }
+    senderAddressList = senderAddressList.filter(address => !cachedProfiles.some(cached => cached.senderAddress === address));
+    if (senderAddressList.length === 0) {
+      return;
+    }
+    senderAddressList.forEach(senderAddress => cachedProfiles.push({ senderAddress, photoURL: null }));
+
+    const responseJSON = await this.getMatches(senderAddressList);
+
+    // Parse result to get an array of { senderAddress, photoURL } pairs
+    if (responseJSON.matches) {
+      responseJSON.matches.forEach(match => {
+        const cachedProfile = this.getCachedProfile(match.lookupId);
+        cachedProfile.photoURL = responseJSON.people[match.personId[0]].photo[0].url;
+      });
+    }
+  }
+};
+
+export default profilePhoto;


### PR DESCRIPTION
* after processing emails, fetch and cache profile photos based for senders
* when rendering avatar, if photo is available, use that
* restructure and simplify participant methods
* email body isn't always available, use subject text to check for calendar reminders

h/t to @russelldc for the logic to fetch the profile photos