### PR TITLE
feat(#54): add keyboard navigation

### DIFF
--- a/src/js/content/constants.js
+++ b/src/js/content/constants.js
@@ -21,11 +21,14 @@ export const CLASSES = {
   CALENDAR_ATTACHMENT_CLASS: 'calendar-attachment',
   REMINDER_EMAIL_CLASS: 'reminder',
   UNREAD_BUNDLE_CLASS: 'contains-unread',
-  UNBUNDLED_PARENT_LABEL: 'Unbundled'
+  UNBUNDLED_PARENT_LABEL: 'Unbundled',
+  EMAIL_ROW: 'zA',
+  SELECTED_EMAIL: 'btb'
 };
 
 export const SELECTORS = {
   EMAIL_ROW: '.zA',
+  SELECTED_EMAIL: '.zA.btb',
   EMAIL_CONTAINER: '.BltHke', // could add .nH.oy8Mbf
   PREVIEW_PANE: '.Nu.S3.aZ6'
 };


### PR DESCRIPTION
### keyboard handler
- handle ArrowUp, ArrowDown, KeyJ, KeyK, Escape, and Enter key events
- Open/close previews or bundles with Escape/Enter
- Arrow up/down and J/K will navigate to the next visible row - either a bundle or an email
- Has to be sure to skip any hidden/bundled rows and force the selected row if the bundle should change
- add an indicator the bundle row that matches the currently selected email, if it's in a bundle
- track the currently selected email and bundle with a data-selected attribute to be able to determine what the previous one was when changing with keyboard

### additional tweaks
- adjust the timing of bundle id encoding and use it more consistently
- eliminate data-bundle-id, it was already in data-inbox on the bundle rows