### PR TITLE
fix(outlook): scroll to newly selected email better

### DIFF
--- a/src/js/outlook/bundle.js
+++ b/src/js/outlook/bundle.js
@@ -29,7 +29,7 @@ export default class Bundle {
     this.attrs = attrs;
     this.element = document.querySelector(`${EMAIL_CONTAINER} .${BUNDLE_WRAPPER_CLASS}[data-inbox="${attrs.encodedId}"]`);
     if (attrs.count === 0 && this.element) {
-      this.element.remove();
+      this.element.parentNode.parentNode.remove();
     } else if (!this.element) {
       this.element = this.buildBundleWrapper();
     }
@@ -65,6 +65,8 @@ export default class Bundle {
       ' 00.5-.5v-1a.5.5 0 00-.5-.5h-11zM3 6v5.5c0 .83.67 1.5 1.5 1.5h7c.83 0 1.5-.67 1.5-1.5V6H3z';
 
     const bundleWrapper = htmlToElements(`
+    <div>
+    <div data-animatable="true" class="EeHm8">
     <div
       tabindex="-1"
       class="${EMAIL_ROW} ${BUNDLE_WRAPPER_CLASS}"
@@ -159,25 +161,28 @@ export default class Bundle {
       <span class="hidden-selector"></span>
       <div class="bundle-spacer"></div>
     </div>
+    </div>
+    </div>
     `);
 
     bundleWrapper.onclick = e => this.handleBundleClick(e);
 
     if (emailEl && emailEl.parentNode) {
-      emailEl.parentElement.insertBefore(bundleWrapper, emailEl);
+      const emailWrapper = emailEl.parentNode.parentNode;
+      emailWrapper.parentElement.insertBefore(bundleWrapper, emailWrapper);
     }
     return bundleWrapper;
   }
 
   async handleBundleClick(e) {
-    const bundleRow = e.currentTarget;
+    const bundleRow = e.currentTarget.querySelector('[data-show-emails]');
     const isCheckClick = queryParentSelector(e.target, '.ms-Check');
     if (isCheckClick) {
       this.checkEmails();
     }
 
     const { encodedId } = this.attrs;
-    const order = parseInt(this.element.style.order);
+    const order = parseInt(this.element.parentNode.parentNode.style.order);
     emailPreview.hidePreview();
     const currentlyShowing = bundleRow.getAttribute('data-show-emails') === 'true';
     if (currentlyShowing) {
@@ -190,9 +195,10 @@ export default class Bundle {
         addRemoveClass(bundleRow.querySelector(EMAIL_ROW_INNER_CONTAINER_SELECTOR), SELECTED_ROW, UNSELECTED_ROW);
       }
     } else {
-      document.querySelectorAll(`[data-inbox="bundled"][data-${encodedId}]`).forEach((emailRow, index) => {
+      const bundledEmails = document.querySelectorAll(`[data-inbox="bundled"][data-${encodedId}]`);
+      bundledEmails.forEach((emailRow, index) => {
         emailRow.setAttribute('data-inbox', 'show-bundled');
-        emailRow.style.order = order + index + 1;
+        emailRow.parentNode.parentNode.style.order = order + index + 1;
         if (index === 0) {
           setSelectedRow(emailRow);
         }
@@ -244,11 +250,11 @@ export default class Bundle {
   updateStats({ email, emailEl }) {
     this.email = email;
     this.emailEl = emailEl;
-    this.element.style.order = email.order - 1;
+    this.element.parentNode.parentNode.style.order = email.order - 1;
     const { encodedId } = this.attrs;
-    const order = parseInt(this.element.style.order);
+    const order = parseInt(this.element.parentNode.parentNode.style.order);
     document.querySelectorAll(`[data-inbox="show-bundled"][data-${encodedId}]`).forEach((emailRow, index) => {
-      emailRow.style.order = order + index + 1;
+      emailRow.parentNode.parentNode.style.order = order + index + 1;
     });
 
     const options = getOptions();

--- a/src/js/outlook/constants.js
+++ b/src/js/outlook/constants.js
@@ -1,6 +1,4 @@
-import {
-  addClass, hasClass, buildSelectors, observeForCondition, observeForElement
-} from '../shared/utils.js';
+import { addClass, hasClass, buildSelectors, observeForCondition, observeForElement } from '../shared/utils.js';
 import { CLASSES } from '../shared/constants.js';
 
 export const DEFAULT_PROFILE_URL = '';
@@ -17,26 +15,24 @@ export const OUTLOOK_CLASSES = {
   HIDDEN_EMAIL_ROW: 'l9cM7',
   HIDE_AVATAR: 'oWYiS',
   INBOX: 'mKBmm',
-  OLD_PREVIEW_ELEMENTS: 'c2xp6',
-  NEW_PREVIEW_ELEMENTS: 'MtujV',
+  PREVIEW_WRAPPER: 'MtujV',
   PREVIEW_CONTAINER: 'Mq3cC',
   PREVIEW_COMPOSE: 'soZTT',
   SCROLLBAR_ELEMENT: 'zXLz3',
   SELECTED_ROW: 'epBmH',
   TIME_ROW: 'Cnnoo',
   UNREAD_EMAIL_ROW: 'VcZPl',
-  UNSELECTED_ROW: 'IjQyD'
+  UNSELECTED_ROW: 'IjQyD',
 };
 
 const CLASS_SELECTORS = buildSelectors(OUTLOOK_CLASSES);
 
 export const OUTLOOK_SELECTORS = {
   ...CLASS_SELECTORS,
-  PREVIEW_ELEMENTS: `${CLASS_SELECTORS.NEW_PREVIEW_ELEMENTS},${CLASS_SELECTORS.OLD_PREVIEW_ELEMENTS}`,
   PREVIEW_PANE: `${CLASS_SELECTORS.PREVIEW_CONTAINER} #ReadingPaneContainerId`,
   SELECTED_EMAIL: `${CLASS_SELECTORS.EMAIL_ROW}[aria-selected="true"]`,
   EMAIL_PARTICIPANTS: `${CLASS_SELECTORS.EMAIL_PARTICIPANT_CONTAINERS} span, .Ljsqx span, .uSUBc span`,
-  EMAIL_LABELS: `${CLASS_SELECTORS.EMAIL_LABEL_CONTAINERS} ${CLASS_SELECTORS.EMAIL_LABEL_TEXTS}`
+  EMAIL_LABELS: `${CLASS_SELECTORS.EMAIL_LABEL_CONTAINERS} ${CLASS_SELECTORS.EMAIL_LABEL_TEXTS}`,
 };
 
 const findPrefixedClass = (el, prefix) => Array.from(el?.classList).find(c => c.startsWith(prefix));
@@ -48,7 +44,7 @@ const CHECKBOX_CLASSES = {
   UNCHECKED_CIRCLE: '',
   CHECKED_ROOT: '',
   CHECKED_CHECK: '',
-  CHECKED_CIRCLE: ''
+  CHECKED_CIRCLE: '',
 };
 
 export const getCheckboxClasses = () => CHECKBOX_CLASSES;
@@ -58,13 +54,13 @@ export const findCheckboxClasses = async () => {
   }
   const firstEmailCheckbox = await observeForElement(document, '.ms-Check[class*="root-"]');
   CHECKBOX_CLASSES.UNCHECKED_ROOT = findPrefixedClass(firstEmailCheckbox, 'root-');
-  CHECKBOX_CLASSES.UNCHECKED_CHECK = findPrefixedClasses(firstEmailCheckbox.querySelector('.ms-Check-check'), [ 'check-', 'css-', 'root-' ]);
-  CHECKBOX_CLASSES.UNCHECKED_CIRCLE = findPrefixedClasses(firstEmailCheckbox.querySelector('.ms-Check-circle'), [ 'circle-', 'css-', 'root-' ]);
+  CHECKBOX_CLASSES.UNCHECKED_CHECK = findPrefixedClasses(firstEmailCheckbox.querySelector('.ms-Check-check'), ['check-', 'css-', 'root-']);
+  CHECKBOX_CLASSES.UNCHECKED_CIRCLE = findPrefixedClasses(firstEmailCheckbox.querySelector('.ms-Check-circle'), ['circle-', 'css-', 'root-']);
   firstEmailCheckbox.click();
   await observeForCondition(firstEmailCheckbox, () => !hasClass(firstEmailCheckbox, CHECKBOX_CLASSES.UNCHECKED_ROOT));
   CHECKBOX_CLASSES.CHECKED_ROOT = findPrefixedClass(firstEmailCheckbox, 'root-');
-  CHECKBOX_CLASSES.CHECKED_CHECK = findPrefixedClasses(firstEmailCheckbox.querySelector('.ms-Check-check'), [ 'check-', 'css-', 'root-' ]);
-  CHECKBOX_CLASSES.CHECKED_CIRCLE = findPrefixedClasses(firstEmailCheckbox.querySelector('.ms-Check-circle'), [ 'circle-', 'css-', 'root-' ]);
+  CHECKBOX_CLASSES.CHECKED_CHECK = findPrefixedClasses(firstEmailCheckbox.querySelector('.ms-Check-check'), ['check-', 'css-', 'root-']);
+  CHECKBOX_CLASSES.CHECKED_CIRCLE = findPrefixedClasses(firstEmailCheckbox.querySelector('.ms-Check-circle'), ['circle-', 'css-', 'root-']);
   firstEmailCheckbox.click();
   document.querySelectorAll(`${CLASSES.BUNDLE_WRAPPER_CLASS} .ms-Check`).forEach(el => addClass(el, CHECKBOX_CLASSES.UNCHECKED_ROOT));
   document.querySelectorAll(`${CLASSES.BUNDLE_WRAPPER_CLASS} .ms-Check-circle`).forEach(el => addClass(el, CHECKBOX_CLASSES.UNCHECKED_CIRCLE));

--- a/src/js/outlook/email.js
+++ b/src/js/outlook/email.js
@@ -13,8 +13,8 @@ export default class Email {
   constructor(emailEl, emailIndex) {
     this.emailEl = emailEl;
     this.order = emailIndex * 100;
-    if (!this.emailEl.style.order) {
-      this.emailEl.style.order = this.order;
+    if (!this.emailEl.parentNode.parentNode.style.order) {
+      this.emailEl.parentNode.parentNode.style.order = this.order;
     }
 
     const options = getOptions();
@@ -120,7 +120,7 @@ export default class Email {
       this.emailEl.setAttribute('data-bundles', bundles); // labels.map(label => encodeBundleId(label.title)).join('||'));
     } else {
       this.emailEl.setAttribute('data-inbox', 'email');
-      this.emailEl.style.order = this.order;
+      this.emailEl.parentNode.parentNode.style.order = this.order;
       if (isUnbundled) {
         labels.forEach(label => {
           if (label.title.includes(CLASSES.UNBUNDLED_PARENT_LABEL)) {

--- a/src/js/outlook/emailPreview.js
+++ b/src/js/outlook/emailPreview.js
@@ -50,17 +50,15 @@ export default {
     if (!previewPlaceholder) {
       previewPlaceholder = htmlToElements('<div class="preview-placeholder"><div class="preview-scroll-target"></div></div>');
     }
-    previewPlaceholder.style.order = parseInt(this.currentEmail.style.order) + 1;
     this.currentEmail.parentNode.insertBefore(previewPlaceholder, this.currentEmail.nextSibling);
     this.setPreviewPosition(previewPane);
   },
   showPreviewPane(previewPane) {
     this.movePreviewPane(previewPane);
     const previewPlaceholder = document.querySelector('.preview-placeholder');
-    const previewScrolTarget = document.querySelector('.preview-scroll-target');
+    const previewScrollTarget = document.querySelector('.preview-scroll-target');
     addClass(previewPane, 'show-preview');
     const emailContainer = document.querySelector(EMAIL_CONTAINER);
-    addClass(emailContainer, 'preview-showing');
     this.previewShowing = true;
     const adjustPreviewSize = () => {
       if (hasClass(previewPane, 'preview-compose')) {
@@ -80,7 +78,7 @@ export default {
           if (this.currentEmail.getAttribute('data-previewing') !== 'true') {
             document.querySelectorAll('[data-previewing="true"]').forEach(el => el.setAttribute('data-previewing', false));
             this.currentEmail.setAttribute('data-previewing', true);
-            setTimeout(() => previewScrolTarget.scrollIntoView({ behavior: 'smooth' }), 0);
+            setTimeout(() => previewScrollTarget.scrollIntoView({ behavior: 'smooth' }), 0);
           }
         }
       }
@@ -97,9 +95,11 @@ export default {
       return;
     }
     const previewPlaceholder = document.querySelector('.preview-placeholder');
-    const { offsetTop } = previewPlaceholder;
-    const totalTop = addPixels(offsetTop, 39);
-    previewPane.style.top = totalTop;
+    const { offsetTop } = previewPlaceholder.parentNode.parentNode;
+    const totalTop = addPixels(offsetTop, 36, 39);
+    if (previewPane.style.top !== totalTop) {
+      previewPane.style.top = totalTop;
+    }
   },
   hidePreviewPane(previewPane) {
     const previewingEmail = document.querySelector('[data-previewing]');
@@ -110,7 +110,6 @@ export default {
       removeClass(previewPane, 'show-preview');
     }
     const emailContainer = document.querySelector(EMAIL_CONTAINER);
-    removeClass(emailContainer, 'preview-showing');
     this.previewShowing = false;
     const previewPlaceholder = document.querySelector('.preview-placeholder');
     if (previewPlaceholder) {

--- a/src/js/outlook/emailPreview.js
+++ b/src/js/outlook/emailPreview.js
@@ -1,9 +1,19 @@
-import { addClass, addRemoveClass, addPixels, observeForElement, removeClass, runObserver, hasClass, observeForRemoval } from '../shared/utils.js';
+import {
+  addClass,
+  addRemoveClass,
+  addPixels,
+  hasClass,
+  htmlToElements,
+  observeForElement,
+  observeForRemoval,
+  removeClass,
+  runObserver,
+} from '../shared/utils.js';
 import { CLASSES } from '../shared/constants.js';
 import { OUTLOOK_SELECTORS } from './constants.js';
 
 const { BUNDLE_WRAPPER_CLASS } = CLASSES;
-const { PREVIEW_COMPOSE, PREVIEW_PANE, PREVIEW_ELEMENTS, EMAIL_CONTAINER } = OUTLOOK_SELECTORS;
+const { PREVIEW_COMPOSE, PREVIEW_PANE, PREVIEW_WRAPPER, EMAIL_CONTAINER } = OUTLOOK_SELECTORS;
 
 export default {
   currentEmail: null,
@@ -38,8 +48,7 @@ export default {
     // this creates a space for the preview and uses absolute positioning to make it look like it's under the current email
     let previewPlaceholder = document.querySelector('.preview-placeholder');
     if (!previewPlaceholder) {
-      previewPlaceholder = document.createElement('div');
-      addClass(previewPlaceholder, 'preview-placeholder');
+      previewPlaceholder = htmlToElements('<div class="preview-placeholder"><div class="preview-scroll-target"></div></div>');
     }
     previewPlaceholder.style.order = parseInt(this.currentEmail.style.order) + 1;
     this.currentEmail.parentNode.insertBefore(previewPlaceholder, this.currentEmail.nextSibling);
@@ -48,6 +57,7 @@ export default {
   showPreviewPane(previewPane) {
     this.movePreviewPane(previewPane);
     const previewPlaceholder = document.querySelector('.preview-placeholder');
+    const previewScrolTarget = document.querySelector('.preview-scroll-target');
     addClass(previewPane, 'show-preview');
     const emailContainer = document.querySelector(EMAIL_CONTAINER);
     addClass(emailContainer, 'preview-showing');
@@ -57,21 +67,29 @@ export default {
         previewPane.style.height = null;
         return;
       }
-      const previewEls = Array.from(previewPane.querySelectorAll(PREVIEW_ELEMENTS));
-      previewPlaceholder.style.height = addPixels(...previewEls.map(el => el.offsetHeight), 12);
-      previewPane.style.height = previewPlaceholder.style.height;
-      previewPane.style.width = getComputedStyle(previewPlaceholder).width;
+      const previewWrapper = previewPane.querySelector(PREVIEW_WRAPPER);
+      if (previewWrapper.childElementCount > 1) {
+        const previewHeight = addPixels(previewWrapper.offsetHeight, 12);
+        const previewWidth = getComputedStyle(previewPlaceholder).width;
+        const { height, width } = previewPlaceholder.style;
+        const sizeChanged = previewHeight !== height || previewWidth !== width;
+        if (sizeChanged) {
+          previewPlaceholder.style.height = previewHeight;
+          previewPane.style.height = previewHeight;
+          previewPane.style.width = previewWidth;
+          if (this.currentEmail.getAttribute('data-previewing') !== 'true') {
+            document.querySelectorAll('[data-previewing="true"]').forEach(el => el.setAttribute('data-previewing', false));
+            this.currentEmail.setAttribute('data-previewing', true);
+            setTimeout(() => previewScrolTarget.scrollIntoView({ behavior: 'smooth' }), 0);
+          }
+        }
+      }
       this.previewObserver.observe(previewPane, { subtree: true, attributes: true });
     };
     this.previewObserver = runObserver(previewPane, { subtree: true, attributes: true }, adjustPreviewSize, false, this.previewObserver);
     adjustPreviewSize();
 
     this.setPreviewPosition(previewPane);
-    if (this.currentEmail.getAttribute('data-previewing') !== 'true') {
-      document.querySelectorAll('[data-previewing="true"]').forEach(el => el.setAttribute('data-previewing', false));
-      this.currentEmail.setAttribute('data-previewing', true);
-      previewPane.scrollIntoView({ behavior: 'smooth' });
-    }
   },
   setPreviewPosition(previewPane) {
     if (hasClass(previewPane, 'preview-compose')) {

--- a/src/js/outlook/emailPreview.js
+++ b/src/js/outlook/emailPreview.js
@@ -68,7 +68,7 @@ export default {
         return;
       }
       const previewWrapper = previewPane.querySelector(PREVIEW_WRAPPER);
-      if (previewWrapper.childElementCount > 1) {
+      if (previewWrapper?.childElementCount > 1) {
         const previewHeight = addPixels(previewWrapper.offsetHeight, 12);
         const previewWidth = getComputedStyle(previewPlaceholder).width;
         const { height, width } = previewPlaceholder.style;

--- a/src/js/outlook/inbox.js
+++ b/src/js/outlook/inbox.js
@@ -47,60 +47,52 @@ export default {
 
     // Start from last email on page and head towards first
     let lastEmailEl;
-    let visibleEmptyEmails;
-    const loaderEl = document.querySelector('.jxHeC');
-    if (loaderEl) {
-      loaderEl.style.order = emailElements.length * 100;
-    }
     // TODO: this for loop is an area that might be able to be shared with gmail
     for (let i = emailElements.length - 1; i >= 0; i--) {
       const emailElement = emailElements[i];
       if (i === emailElements.length - 1) {
         lastEmailEl = emailElement;
       }
-      const emptyEmail = emailElement.childElementCount === 0;
-      if (emptyEmail && !visibleEmptyEmails) {
-        visibleEmptyEmails = isInViewport(emailElement);
-      } else {
-        const email = new Email(emailElement, i);
+      const email = new Email(emailElement, i);
 
-        const emailLabels = email.getLabels().map(label => label.title);
+      const emailLabels = email.getLabels().map(label => label.title);
 
-        // Collect senders, message count and unread stats for each label
-        if (emailLabels.length && email.isBundled()) {
-          const firstParticipant = email.isReminder() ? 'Reminder' : email.getParticipants()[0].name;
-          emailLabels.forEach(label => {
-            const encodedId = encodeBundleId(label);
-            if (!labelStats[encodedId]) {
-              labelStats[encodedId] = {
-                title: label,
-                encodedId,
-                count: 1,
-                senders: [
-                  {
-                    name: firstParticipant,
-                    isUnread: email.isUnread(),
-                  },
-                ],
-              };
+      // Collect senders, message count and unread stats for each label
+      if (emailLabels.length && email.isBundled()) {
+        const firstParticipant = email.isReminder() ? 'Reminder' : email.getParticipants()[0].name;
+        emailLabels.forEach(label => {
+          const encodedId = encodeBundleId(label);
+          if (!labelStats[encodedId]) {
+            labelStats[encodedId] = {
+              title: label,
+              encodedId,
+              count: 1,
+              senders: [
+                {
+                  name: firstParticipant,
+                  isUnread: email.isUnread(),
+                },
+              ],
+            };
+            if (!hasClass(email.emailEl, 'bundle-last-email')) {
               removeClass(document.querySelector(`[data-${encodedId}].bundle-last-email`), 'bundle-last-email');
               addClass(email.emailEl, 'bundle-last-email');
-            } else {
-              labelStats[encodedId].count++;
-              labelStats[encodedId].senders.push({
-                name: firstParticipant,
-                isUnread: email.isUnread(),
-              });
             }
-            labelStats[encodedId].email = email;
-            labelStats[encodedId].emailEl = email.emailEl;
-            if (email.isUnread()) {
-              labelStats[encodedId].containsUnread = true;
-            }
-          });
-        }
-        email.getParticipants().forEach(participant => participantEmails.add(participant.email));
+          } else {
+            labelStats[encodedId].count++;
+            labelStats[encodedId].senders.push({
+              name: firstParticipant,
+              isUnread: email.isUnread(),
+            });
+          }
+          labelStats[encodedId].email = email;
+          labelStats[encodedId].emailEl = email.emailEl;
+          if (email.isUnread()) {
+            labelStats[encodedId].containsUnread = true;
+          }
+        });
       }
+      email.getParticipants().forEach(participant => participantEmails.add(participant.email));
     }
 
     // Update bundle stats
@@ -118,20 +110,6 @@ export default {
       });
     }
 
-    if (visibleEmptyEmails) {
-      const emailContainer = document.querySelector(EMAIL_CONTAINER);
-      if (hasClass(emailContainer, 'preview-showing')) {
-        removeClass(emailContainer, 'preview-showing');
-        addClass(emailContainer, 'preview-showing');
-      } else {
-        const firstEmailEl = document.querySelector(`${SCROLLBAR_ELEMENT} > div:nth-child(1)`);
-        firstEmailEl.style.height = '100vh';
-        lastEmailEl.scrollIntoView();
-        firstEmailEl.style.height = '';
-        firstEmailEl.scrollIntoView();
-      }
-    }
-
     document.querySelectorAll(TIME_ROW).forEach(timeRow => {
       const nextVisibleRow = findNextVisibleRow(timeRow, true, true);
       if (!nextVisibleRow || hasClass(nextVisibleRow, TIME_ROW_CLASS)) {
@@ -145,7 +123,7 @@ export default {
   getBundledLabels() {
     const bundleRows = Array.from(document.querySelectorAll(`${EMAIL_CONTAINER} .${BUNDLE_WRAPPER_CLASS}`));
     return bundleRows.reduce((bundles, el) => {
-      bundles[el.getAttribute('data-inbox')] = el;
+      bundles[el.getAttribute('data-inbox')] = el.parentNode.parentNode;
       return bundles;
     }, {});
   },

--- a/src/js/outlook/keyboard.js
+++ b/src/js/outlook/keyboard.js
@@ -17,13 +17,14 @@ export default {
     const currentBundle = document.querySelector(`${SELECTED_EMAIL}.${BUNDLE_WRAPPER_CLASS}`);
     const mainContainer = document.querySelector('.AO');
     const parameters = {
-      event,
-      target: event.target,
-      currentTarget: event.currentTarget,
-      currentRow,
       currentBundle,
+      currentRow,
+      currentTarget: event.currentTarget,
+      event,
       keyCode: event.code,
       mainContainer,
+      navigate: this.navigate,
+      target: event.target,
       shiftKey: event.shiftKey,
     };
 
@@ -56,11 +57,11 @@ export default {
         }
       }
     },
-    KeyE: ({ currentRow, ...rest }) => {
+    KeyE: ({ currentRow, navigate, ...rest }) => {
       if (emailPreview.previewShowing) {
         emailPreview.emailClicked(currentRow);
       }
-      this.navigate({ currentRow, ...rest });
+      navigate({ currentRow, ...rest });
     },
     Quote: ({ mainContainer, shiftKey }) => mainContainer.scrollBy(0, shiftKey ? -250 : -25),
     Semicolon: ({ mainContainer, shiftKey }) => mainContainer.scrollBy(0, shiftKey ? 250 : 25),

--- a/src/js/outlook/outlookUtils.js
+++ b/src/js/outlook/outlookUtils.js
@@ -1,12 +1,7 @@
-import {
-  OUTLOOK_CLASSES,
-  OUTLOOK_SELECTORS
-} from './constants.js';
+import { OUTLOOK_CLASSES, OUTLOOK_SELECTORS } from './constants.js';
 import { addRemoveClass, hasClass } from '../shared/utils.js';
 
-const {
-  SELECTED_ROW, UNSELECTED_ROW, EMAIL_ROW: EMAIL_ROW_CLASS, TIME_ROW
-} = OUTLOOK_CLASSES;
+const { SELECTED_ROW, UNSELECTED_ROW, EMAIL_ROW: EMAIL_ROW_CLASS, TIME_ROW } = OUTLOOK_CLASSES;
 const { EMAIL_ROW_INNER_CONTAINER } = OUTLOOK_SELECTORS;
 
 let foundEmail;
@@ -26,8 +21,8 @@ export const getMyEmailAddress = () => {
 };
 
 const deconstructEmail = email => {
-  const [ address, fullDomain ] = email.split('@');
-  const [ domain, tld ] = fullDomain.split('.');
+  const [address, fullDomain] = email.split('@');
+  const [domain, tld] = fullDomain.split('.');
   return { address, domain, tld };
 };
 
@@ -98,14 +93,14 @@ export const setSelectedRow = row => {
 export const findNextVisibleRow = (currentRow, searchNext = true, includeTimeRows = false) => {
   const navigator = searchNext ? 'nextSibling' : 'previousSibling';
   const currentBundle = currentRow.getAttribute('data-bundles');
-  let nextRow = currentRow[navigator];
+  let nextRow = currentRow.parentNode.parentNode[navigator]?.firstElementChild?.firstElementChild;
   if (!nextRow) return;
   let isEmailOrTimeRow = hasClass(nextRow, EMAIL_ROW_CLASS) || (includeTimeRows && hasClass(nextRow, TIME_ROW));
   let isEmailBundled = nextRow.getAttribute('data-inbox') === 'bundled';
   let isSameBundle = nextRow.getAttribute('data-bundles') === currentBundle;
   // let isPreviousBundle = previousEmail.getAttribute('data-inbox') === 'bundled' && nextRow === previousBundle;
   while (nextRow && (!isEmailOrTimeRow || isEmailBundled || !isSameBundle)) {
-    nextRow = nextRow[navigator];
+    nextRow = nextRow.parentNode.parentNode[navigator]?.firstElementChild?.firstElementChild;
     if (nextRow) {
       isEmailOrTimeRow = hasClass(nextRow, EMAIL_ROW_CLASS) || (includeTimeRows && hasClass(nextRow, TIME_ROW));
       isEmailBundled = nextRow.getAttribute('data-inbox') === 'bundled';

--- a/src/scss/outlook/email-list.scss
+++ b/src/scss/outlook/email-list.scss
@@ -2,39 +2,9 @@ html[dir='ltr'] {
   body {
     //main inbox element, has data-max-width on it
     .q9iRC {
-      // for scrolling preview
-      &.preview-showing {
-        // element right above data-app-section=MessageList
-        .HOVUa {
-          .G8_Dc {
-            overflow-y: auto;
-            height: auto;
-            //main email list
-            .XW2m0 {
-              max-height: unset;
-              height: auto;
-
-              // scrollbar element around messages
-              .jEpCF {
-                overflow: unset;
-
-                // element directly inside the scrollbar
-                .zXLz3 {
-                  width: calc(100% - 18px);
-                }
-              }
-            }
-            // shared class on several containers in the message list
-            .Cz7T5 {
-              overflow: unset;
-            }
-
-            // class in between some of the shared one above
-            .ONAp_ {
-              overflow: unset;
-            }
-          }
-        }
+      .G8_Dc {
+        overflow-y: auto;
+        height: auto;
       }
 
       // element directly inside of data-max-width
@@ -58,14 +28,17 @@ html[dir='ltr'] {
             //email list scroll container
             .jEpCF {
               padding-left: 18px;
-              max-height: calc(100vh - 134px);
-              overflow-y: auto;
+              height: unset !important;
 
               //email rows container
-              .zXLz3 {
+              > div {
                 display: flex;
+                height: unset !important;
                 flex-direction: column;
                 position: initial;
+                > div {
+                  position: unset !important;
+                }
               }
             }
 

--- a/src/scss/outlook/email-preview.scss
+++ b/src/scss/outlook/email-preview.scss
@@ -1,3 +1,11 @@
+.preview-placeholder {
+  position: relative;
+  .preview-scroll-target {
+    position: absolute;
+    top: -80px;
+  }
+}
+
 // email-preview
 .Mq3cC {
   //preview elements have margin-left: 8px and margin-right: 19px

--- a/src/scss/outlook/email-preview.scss
+++ b/src/scss/outlook/email-preview.scss
@@ -97,14 +97,19 @@
       align-items: flex-end;
       bottom: 41px;
       left: unset;
-      right: 0;
+      right: 18px;
       border: 1px solid;
       z-index: 15;
       max-height: calc(100% - 41px);
+      width: unset !important;
+      @media (max-width: 1375px) {
+        left: calc(100vw - 1000px) !important;
+        right: unset !important;
+      }
 
       .soZTT {
         position: initial;
-        width: 50vw;
+        width: 600px;
         max-height: calc(100vh - 200px);
 
         &.compose-reminder {
@@ -146,8 +151,9 @@
 
   // bottom bar showing draft emails as tabs
   .nuum5 {
-    position: fixed;
+    position: absolute;
     bottom: 0;
+    z-index: 100;
   }
 
   // preview container


### PR DESCRIPTION
- add a scroll target inside the preview placeholder to be able to account for fixed headers
- preview now seems to have a wrapper we can grab instead of an array of elements to deal with
- wait for the preview wrapper to have more than just the header inside it (i.e. that the actual email has loaded) so we can get a better preview size
- only set preview sizes if sizes have changed, mostly for assumed better performance
- fix navigate on archive