### PR TITLE
fix: update for new outlook checkboxes

### DIFF
--- a/src/js/content/bundle.js
+++ b/src/js/content/bundle.js
@@ -1,6 +1,6 @@
 import { CLASSES, GMAIL_CLASSES, GMAIL_SELECTORS } from './constants.js';
 import emailPreview from './emailPreview.js';
-import { addRemoveClass, htmlToElements, observeForElement, observeForRemoval, hasClass } from '../shared/utils.js';
+import { hasClass, htmlToElements, replaceClass, observeForRemoval } from '../shared/utils.js';
 import { checkImportantMarkers, getCurrentBundle, isInBundle, openBundle, openInbox, setCurrentBundle } from './emailUtils.js';
 
 import { getOptions } from '../shared/options.js';
@@ -135,9 +135,9 @@ export default class Bundle {
 
   checkUnread() {
     if (this.attrs.containsUnread) {
-      addRemoveClass(this.element, UNREAD_EMAIL_ROW, 'yO');
+      replaceClass(this.element, UNREAD_EMAIL_ROW, 'yO');
     } else {
-      addRemoveClass(this.element, 'yO', UNREAD_EMAIL_ROW);
+      replaceClass(this.element, 'yO', UNREAD_EMAIL_ROW);
     }
   }
 

--- a/src/js/outlook/bundle.js
+++ b/src/js/outlook/bundle.js
@@ -1,7 +1,7 @@
 import { CLASSES } from '../shared/constants.js';
 import { OUTLOOK_CLASSES, getCheckboxClasses, OUTLOOK_SELECTORS } from './constants.js';
 import emailPreview from './emailPreview.js';
-import { addClass, addRemoveClass, htmlToElements, queryParentSelector, removeClass } from '../shared/utils.js';
+import { addClass, replaceClass, htmlToElements, queryParentSelector, removeClass } from '../shared/utils.js';
 
 import { getOptions } from '../shared/options.js';
 import { setSelectedRow } from './outlookUtils.js';
@@ -50,7 +50,8 @@ export default class Bundle {
 
     emailEl.style.width = '100%';
 
-    const { UNCHECKED_ROOT, UNCHECKED_CIRCLE, UNCHECKED_CHECK } = getCheckboxClasses();
+    const { UNCHECKED_CHECKBOX_CLASSES } = getCheckboxClasses();
+    const { ROOT, INPUT, LABEL, CHECKBOX, CHECKMARK } = UNCHECKED_CHECKBOX_CLASSES;
     const columnWidths = Array.from(emailEl.querySelectorAll(`.${EMAIL_COLUMN_CONTAINER} > div`)).map(el => [el.style.width, el.style.paddingLeft]);
     emailEl.style.width = '';
     addClass(emailEl, 'bundle-email');
@@ -87,22 +88,21 @@ export default class Bundle {
                 <div class="XG5Jd d1dnN B3KmY q0f8X"
                   tabindex="-1" role="checkbox" aria-checked="false" aria-label="Select a conversation"
                 >
-                  <div role="presentation"
-                    class="ms-Persona-coin ms-Persona--size28 mP9b0 BQOiO">
-                    <div role="presentation" class="ms-Persona-imageArea">
-                        <div class="ms-Persona-initials" aria-hidden="true"
-                          style="color: ${label.textColor}; background-color: ${label.backgroundColor}; border-color: ${label.borderColor}">
-                          <span>${abbrev}</span>
-                        </div>
-                    </div>
-                  </div>
-                  <div class="ms-Check F5KOS pz2Jt ${UNCHECKED_ROOT}">
-                      <i data-icon-name="CircleRing" aria-hidden="true"
-                          class="ms-Icon ms-Check-circle ${UNCHECKED_CIRCLE}"
-                          style="font-family: controlIcons;"></i>
-                      <i data-icon-name="StatusCircleCheckmark" aria-hidden="true"
-                          class="ms-Icon ms-Check-check LHmNz ${UNCHECKED_CHECK}"
-                          style="font-family: controlIcons;"></i>
+                  <span
+                    role="img" id="avatar-${encodedId}" class="fui-Avatar r81b29z mP9b0 oWYiS BQOiO ___15c0rxp f1w9dchk fxldao9 fy9rknc" aria-label="${title}"
+                  >
+                    <span id="avatar-${encodedId}__initials" class="fui-Avatar__initials rip04v ___456t1b0"
+                    style="color: ${label.textColor}; background-color: ${label.backgroundColor}; border-color: ${label.borderColor}"
+                    >
+                    ${abbrev}</span>
+                  </span>
+                  <div class="ms-Checkbox is-enabled to0aR XG5Jd ${ROOT}">
+                    <input class="${INPUT}" type="checkbox" tabindex="-1" id="checkbox-${encodedId}" data-ktp-execute-target="true"/>
+                    <label class="ms-Checkbox-label ${LABEL}" for="${encodedId}">
+                      <div class="ms-Checkbox-checkbox gy2XW i7xzh ${CHECKBOX}" data-ktp-target="true">
+                        <i data-icon-name="CheckMark" aria-hidden="true" class="ms-Checkbox-checkmark M3Q9u ${CHECKMARK}"></i>
+                      </div>
+                    </label>
                   </div>
                 </div>
                 <div class="${EMAIL_PARTICIPANT_CONTAINERS} W3BHj Dc0o9 Ejrkd">
@@ -140,22 +140,6 @@ export default class Bundle {
               </div>
             </div>
           </div>
-
-          <!-- <div class="QpoLy">
-            <button type="button" class="ms-Button ms-Button--icon pz2Jt XG5Jd BsnNQ uzT44 lZpaF zItCb root-199" data-is-focusable="true">
-            this is the archive button, could be a sweep button for the whole bundle, but doesn't currently work
-              <span class="ms-Button-flexContainer flexContainer-163" data-automationid="splitbuttonprimary">
-                <i data-icon-name="ArchiveRegular" aria-hidden="true" class="ms-Icon root-90 ms-Button-icon icon-200">
-                  <span role="presentation" aria-hidden="true" class="rtm3y">
-                    <svg class="d36TZ" viewBox="0 0 16 16">
-                      <path d="${archiveButtonPath}">
-                      </path>
-                    </svg>
-                  </span>
-                </i>
-              </span>
-            </button>
-          </div>-->
         </div>
       </div>
       <span class="hidden-selector"></span>
@@ -176,7 +160,7 @@ export default class Bundle {
 
   async handleBundleClick(e) {
     const bundleRow = e.currentTarget.querySelector('[data-show-emails]');
-    const isCheckClick = queryParentSelector(e.target, '.ms-Check');
+    const isCheckClick = queryParentSelector(e.target, '.ms-Checkbox');
     if (isCheckClick) {
       this.checkEmails();
     }
@@ -192,7 +176,7 @@ export default class Bundle {
         });
         bundleRow.setAttribute('data-show-emails', !currentlyShowing);
         setSelectedRow(bundleRow);
-        addRemoveClass(bundleRow.querySelector(EMAIL_ROW_INNER_CONTAINER_SELECTOR), SELECTED_ROW, UNSELECTED_ROW);
+        replaceClass(bundleRow.querySelector(EMAIL_ROW_INNER_CONTAINER_SELECTOR), SELECTED_ROW, UNSELECTED_ROW);
       }
     } else {
       const bundledEmails = document.querySelectorAll(`[data-inbox="bundled"][data-${encodedId}]`);
@@ -203,7 +187,7 @@ export default class Bundle {
           setSelectedRow(emailRow);
         }
       });
-      addRemoveClass(bundleRow.querySelector(EMAIL_ROW_INNER_CONTAINER_SELECTOR), UNSELECTED_ROW, SELECTED_ROW);
+      replaceClass(bundleRow.querySelector(EMAIL_ROW_INNER_CONTAINER_SELECTOR), UNSELECTED_ROW, SELECTED_ROW);
       bundleRow.setAttribute('data-show-emails', !currentlyShowing);
     }
   }
@@ -212,39 +196,42 @@ export default class Bundle {
     // none selected -> select all
     // some selected -> select all
     // all selected -> unselect all
-    const unCheckedEmails = document.querySelectorAll(`[data-${this.attrs.encodedId}][aria-selected=false]`);
+    const unCheckedEmails = document.querySelectorAll(`[data-${this.attrs.encodedId}] [aria-checked=false]`);
     const allEmailsChecked = unCheckedEmails.length === 0;
 
-    const emailSelector = `[aria-selected=${allEmailsChecked ? 'true' : 'false'}]`;
-    document.querySelectorAll(`[data-${this.attrs.encodedId}]${emailSelector} [role="checkbox"]`).forEach(checkbox => checkbox.click());
+    const emailSelector = `[aria-checked=${allEmailsChecked ? 'true' : 'false'}]`;
+    document.querySelectorAll(`[data-${this.attrs.encodedId}] ${emailSelector}[role="checkbox"]`).forEach(checkbox => checkbox.click());
   }
 
   updateCheckbox() {
-    const unCheckedEmails = document.querySelectorAll(`[data-${this.attrs.encodedId}][aria-selected=false]`);
+    const unCheckedEmails = document.querySelectorAll(`[data-${this.attrs.encodedId}] [aria-checked=false]`);
     const allEmailsChecked = unCheckedEmails.length === 0;
-    const checkedEmails = document.querySelectorAll(`[data-${this.attrs.encodedId}][aria-selected=true]`);
+    const checkedEmails = document.querySelectorAll(`[data-${this.attrs.encodedId}] [aria-checked=true]`);
     const anyEmailsChecked = checkedEmails.length > 0;
 
-    const action = !allEmailsChecked ? 'UNCHECK' : 'CHECK';
-    const unaction = action === 'CHECK' ? 'UNCHECK' : 'CHECK';
-
-    this.updateCheckboxEl('.ms-Check', 'ROOT', action, unaction);
-    this.updateCheckboxEl('.ms-Check-circle', 'CIRCLE', action, unaction);
-    this.updateCheckboxEl('.ms-Check-check', 'CHECK', action, unaction);
-
-    const checkboxContainer = this.element.querySelector('[role="checkbox"');
+    const checkboxContainer = this.element.querySelector('[role="checkbox"]');
+    checkboxContainer.setAttribute('aria-checked', anyEmailsChecked);
+    const avatarContainer = this.element.querySelector('.fui-Avatar');
     if (anyEmailsChecked) {
-      addClass(checkboxContainer, HIDE_AVATAR);
+      addClass(avatarContainer, HIDE_AVATAR);
     } else {
-      removeClass(checkboxContainer, HIDE_AVATAR);
+      removeClass(avatarContainer, HIDE_AVATAR);
     }
-  }
+    const { CHECKED_CHECKBOX_CLASSES, UNCHECKED_CHECKBOX_CLASSES } = getCheckboxClasses();
+    const addClasses = allEmailsChecked ? CHECKED_CHECKBOX_CLASSES : UNCHECKED_CHECKBOX_CLASSES;
+    const removeClasses = allEmailsChecked ? UNCHECKED_CHECKBOX_CLASSES : CHECKED_CHECKBOX_CLASSES;
 
-  updateCheckboxEl(selector, suffix, action, unaction) {
-    const checkboxClasses = getCheckboxClasses();
-
-    const check = this.element.querySelector(selector);
-    addRemoveClass(check, checkboxClasses[`${action}ED_${suffix}`], checkboxClasses[`${unaction}ED_${suffix}`]);
+    const checkboxEl = this.element.querySelector('.ms-Checkbox');
+    if (allEmailsChecked) {
+      addClass(checkboxEl, 'is-checked');
+    } else {
+      removeClass(checkboxEl, 'is-checked');
+    }
+    replaceClass(checkboxEl, addClasses.ROOT, removeClasses.ROOT);
+    replaceClass(checkboxEl.querySelector('input'), addClasses.INPUT, removeClasses.INPUT);
+    replaceClass(checkboxEl.querySelector('label'), addClasses.LABEL, removeClasses.LABEL);
+    replaceClass(checkboxEl.querySelector('.ms-Checkbox-checkbox'), addClasses.CHECKBOX, removeClasses.CHECKBOX);
+    replaceClass(checkboxEl.querySelector('.ms-Checkbox-checkmark'), addClasses.CHECKMARK, removeClasses.CHECKMARK);
   }
 
   updateStats({ email, emailEl }) {

--- a/src/js/outlook/constants.js
+++ b/src/js/outlook/constants.js
@@ -1,4 +1,4 @@
-import { addClass, hasClass, buildSelectors, observeForCondition, observeForElement } from '../shared/utils.js';
+import { addClass, buildSelectors, observeForElement } from '../shared/utils.js';
 import { CLASSES } from '../shared/constants.js';
 
 export const DEFAULT_PROFILE_URL = '';
@@ -35,34 +35,48 @@ export const OUTLOOK_SELECTORS = {
   EMAIL_LABELS: `${CLASS_SELECTORS.EMAIL_LABEL_CONTAINERS} ${CLASS_SELECTORS.EMAIL_LABEL_TEXTS}`,
 };
 
-const findPrefixedClass = (el, prefix) => Array.from(el?.classList).find(c => c.startsWith(prefix));
-const findPrefixedClasses = (el, prefixes) => prefixes.map(prefix => findPrefixedClass(el, prefix));
+const findPrefixedClass = (el, prefix) => el && Array.from(el?.classList).find(c => c.startsWith(prefix));
 
-const CHECKBOX_CLASSES = {
-  UNCHECKED_ROOT: '',
-  UNCHECKED_CHECK: '',
-  UNCHECKED_CIRCLE: '',
-  CHECKED_ROOT: '',
-  CHECKED_CHECK: '',
-  CHECKED_CIRCLE: '',
+const CHECKED_CHECKBOX_CLASSES = {
+  ROOT: '',
+  INPUT: '',
+  LABEL: '',
+  CHECKBOX: '',
+  CHECKMARK: '',
+};
+const UNCHECKED_CHECKBOX_CLASSES = {
+  ROOT: '',
+  INPUT: '',
+  LABEL: '',
+  CHECKBOX: '',
+  CHECKMARK: '',
 };
 
-export const getCheckboxClasses = () => CHECKBOX_CLASSES;
+const findClasses = (firstEmailCheckbox, classesObj) => {
+  classesObj.ROOT = findPrefixedClass(firstEmailCheckbox.querySelector('.ms-Checkbox'), 'root-');
+  classesObj.INPUT = findPrefixedClass(firstEmailCheckbox.querySelector('input'), 'input-');
+  classesObj.LABEL = findPrefixedClass(firstEmailCheckbox.querySelector('label'), 'label-');
+  classesObj.CHECKBOX = findPrefixedClass(firstEmailCheckbox.querySelector('.ms-Checkbox-checkbox'), 'checkbox-');
+  classesObj.CHECKMARK = findPrefixedClass(firstEmailCheckbox.querySelector('.ms-Checkbox-checkmark'), 'checkmark-');
+};
+
+export const getCheckboxClasses = () => ({ CHECKED_CHECKBOX_CLASSES, UNCHECKED_CHECKBOX_CLASSES });
 export const findCheckboxClasses = async () => {
-  if (CHECKBOX_CLASSES.UNCHECKED_ROOT !== '') {
+  if (!!CHECKED_CHECKBOX_CLASSES.ROOT) {
     return;
   }
-  const firstEmailCheckbox = await observeForElement(document, '.ms-Check[class*="root-"]');
-  CHECKBOX_CLASSES.UNCHECKED_ROOT = findPrefixedClass(firstEmailCheckbox, 'root-');
-  CHECKBOX_CLASSES.UNCHECKED_CHECK = findPrefixedClasses(firstEmailCheckbox.querySelector('.ms-Check-check'), ['check-', 'css-', 'root-']);
-  CHECKBOX_CLASSES.UNCHECKED_CIRCLE = findPrefixedClasses(firstEmailCheckbox.querySelector('.ms-Check-circle'), ['circle-', 'css-', 'root-']);
+  const firstEmailCheckbox = await observeForElement(document, `${CLASS_SELECTORS.EMAIL_ROW} [role="checkbox"]`);
   firstEmailCheckbox.click();
-  await observeForCondition(firstEmailCheckbox, () => !hasClass(firstEmailCheckbox, CHECKBOX_CLASSES.UNCHECKED_ROOT));
-  CHECKBOX_CLASSES.CHECKED_ROOT = findPrefixedClass(firstEmailCheckbox, 'root-');
-  CHECKBOX_CLASSES.CHECKED_CHECK = findPrefixedClasses(firstEmailCheckbox.querySelector('.ms-Check-check'), ['check-', 'css-', 'root-']);
-  CHECKBOX_CLASSES.CHECKED_CIRCLE = findPrefixedClasses(firstEmailCheckbox.querySelector('.ms-Check-circle'), ['circle-', 'css-', 'root-']);
+  await observeForElement(document, `${CLASS_SELECTORS.EMAIL_ROW} [aria-checked="true"] .is-checked.ms-Checkbox[class*="root-"]`);
+  findClasses(firstEmailCheckbox, CHECKED_CHECKBOX_CLASSES);
+  const uncheckedCheckbox = document.querySelector(`${CLASS_SELECTORS.EMAIL_ROW}:not(.bundle-wrapper) [role="checkbox"][aria-checked="false"]`);
+  findClasses(uncheckedCheckbox, UNCHECKED_CHECKBOX_CLASSES);
   firstEmailCheckbox.click();
-  document.querySelectorAll(`${CLASSES.BUNDLE_WRAPPER_CLASS} .ms-Check`).forEach(el => addClass(el, CHECKBOX_CLASSES.UNCHECKED_ROOT));
-  document.querySelectorAll(`${CLASSES.BUNDLE_WRAPPER_CLASS} .ms-Check-circle`).forEach(el => addClass(el, CHECKBOX_CLASSES.UNCHECKED_CIRCLE));
-  document.querySelectorAll(`${CLASSES.BUNDLE_WRAPPER_CLASS} .ms-Check-check`).forEach(el => addClass(el, CHECKBOX_CLASSES.UNCHECKED_CHECK));
+  document.querySelectorAll(`.${CLASSES.BUNDLE_WRAPPER_CLASS} .ms-Checkbox`).forEach(el => {
+    addClass(el, UNCHECKED_CHECKBOX_CLASSES.ROOT);
+    addClass(el.querySelector('input'), UNCHECKED_CHECKBOX_CLASSES.INPUT);
+    addClass(el.querySelector('label'), UNCHECKED_CHECKBOX_CLASSES.LABEL);
+    addClass(el.querySelector('.ms-Checkbox-checkbox'), UNCHECKED_CHECKBOX_CLASSES.CHECKBOX);
+    addClass(el.querySelector('.ms-Checkbox-checkmark'), UNCHECKED_CHECKBOX_CLASSES.CHECKMARK);
+  });
 };

--- a/src/js/outlook/email.js
+++ b/src/js/outlook/email.js
@@ -28,13 +28,13 @@ export default class Email {
   getLabels() {
     return Array.from(this.emailEl.querySelectorAll(EMAIL_LABELS)).map(labelContainer => {
       const labelTitle = querySelectorText('span', labelContainer);
-
+      const { color, borderColor, backgroundColor } = getComputedStyle(labelContainer);
       return {
         title: labelTitle,
         encodedId: encodeBundleId(labelTitle),
-        borderColor: labelContainer.style.borderColor,
-        textColor: labelContainer.style.color,
-        backgroundColor: labelContainer.style.backgroundColor,
+        borderColor,
+        textColor: color,
+        backgroundColor,
         element: labelContainer,
       };
     });
@@ -167,7 +167,7 @@ export default class Email {
 
   async emailClicked(event) {
     const isButton = queryParentSelector(event.target, '.ms-Button');
-    const isCheckbox = queryParentSelector(event.target, '.ms-Check');
+    const isCheckbox = queryParentSelector(event.target, '.ms-Checkbox');
     const isSelector = hasClass(event.target, 'hidden-selector');
     if (isButton || isCheckbox || isSelector) {
       return;

--- a/src/js/outlook/emailPreview.js
+++ b/src/js/outlook/emailPreview.js
@@ -1,6 +1,6 @@
 import {
   addClass,
-  addRemoveClass,
+  replaceClass,
   addPixels,
   hasClass,
   htmlToElements,
@@ -65,7 +65,7 @@ export default {
         return;
       }
       const previewWrapper = previewPane.querySelector(PREVIEW_WRAPPER);
-      if (previewWrapper?.childElementCount > 1) {
+      if (previewWrapper?.childElementCount >= 1) {
         const previewHeight = addPixels(previewWrapper.offsetHeight, 12);
         const previewWidth = getComputedStyle(previewPlaceholder).width;
         const { height, width } = previewPlaceholder.style;
@@ -137,18 +137,18 @@ export default {
     const composeContainer = previewPane.querySelector(PREVIEW_COMPOSE);
     const previewPlaceholder = document.querySelector('.preview-placeholder');
     if (composeContainer) {
-      addRemoveClass(previewPane, 'preview-compose', 'show-preview');
+      replaceClass(previewPane, 'preview-compose', 'show-preview');
       previewPane.style.top = null;
       previewPane.style.height = null;
       return;
     }
     const selectedEmailOptions = previewPane.querySelector('.J7DEf');
     if (selectedEmailOptions) {
-      addRemoveClass(previewPane, 'show-preview', 'preview-compose');
+      replaceClass(previewPane, 'show-preview', 'preview-compose');
       previewPane.style.height = null;
       return;
     }
-    addRemoveClass(previewPane, 'show-preview', 'preview-compose');
+    replaceClass(previewPane, 'show-preview', 'preview-compose');
     this.hideIfCurrentEmailRemoved(previewPane);
 
     const nothingSelected = previewPane.querySelector('.QYrHp');

--- a/src/js/outlook/inbox.js
+++ b/src/js/outlook/inbox.js
@@ -1,4 +1,4 @@
-import { addClass, encodeBundleId, hasClass, isInViewport, removeClass, runObserver } from '../shared/utils.js';
+import { addClass, encodeBundleId, hasClass, removeClass, runObserver } from '../shared/utils.js';
 import { getOptions, reloadOptions } from '../shared/options.js';
 
 import { findNextVisibleRow } from './outlookUtils.js';
@@ -11,7 +11,7 @@ import emailPreview from './emailPreview.js';
 
 const { BUNDLE_WRAPPER_CLASS } = CLASSES;
 const { TIME_ROW: TIME_ROW_CLASS } = OUTLOOK_CLASSES;
-const { EMAIL_CONTAINER, EMAIL_ROW, HIDDEN_EMAIL_ROW, SELECTED_EMAIL, SCROLLBAR_ELEMENT, TIME_ROW } = OUTLOOK_SELECTORS;
+const { EMAIL_CONTAINER, EMAIL_ROW, HIDDEN_EMAIL_ROW, SELECTED_EMAIL, TIME_ROW } = OUTLOOK_SELECTORS;
 
 export default {
   async observeEmails() {
@@ -46,13 +46,9 @@ export default {
     const participantEmails = new Set();
 
     // Start from last email on page and head towards first
-    let lastEmailEl;
     // TODO: this for loop is an area that might be able to be shared with gmail
     for (let i = emailElements.length - 1; i >= 0; i--) {
       const emailElement = emailElements[i];
-      if (i === emailElements.length - 1) {
-        lastEmailEl = emailElement;
-      }
       const email = new Email(emailElement, i);
 
       const emailLabels = email.getLabels().map(label => label.title);

--- a/src/js/outlook/outlookUtils.js
+++ b/src/js/outlook/outlookUtils.js
@@ -1,5 +1,5 @@
 import { OUTLOOK_CLASSES, OUTLOOK_SELECTORS } from './constants.js';
-import { addRemoveClass, hasClass } from '../shared/utils.js';
+import { replaceClass, hasClass } from '../shared/utils.js';
 
 const { SELECTED_ROW, UNSELECTED_ROW, EMAIL_ROW: EMAIL_ROW_CLASS, TIME_ROW } = OUTLOOK_CLASSES;
 const { EMAIL_ROW_INNER_CONTAINER } = OUTLOOK_SELECTORS;
@@ -21,7 +21,7 @@ export const getMyEmailAddress = () => {
 };
 
 const deconstructEmail = email => {
-  const [address, fullDomain] = email.split('@');
+  const [address, fullDomain = ''] = email.split('@');
   const [domain, tld] = fullDomain.split('.');
   return { address, domain, tld };
 };
@@ -75,7 +75,7 @@ export const matchesMyEmail = email => {
 export const setSelectedRow = row => {
   document.querySelectorAll('[data-selected]').forEach(selectedEl => {
     selectedEl.setAttribute('data-selected', false);
-    addRemoveClass(selectedEl.querySelector(EMAIL_ROW_INNER_CONTAINER), UNSELECTED_ROW, SELECTED_ROW);
+    replaceClass(selectedEl.querySelector(EMAIL_ROW_INNER_CONTAINER), UNSELECTED_ROW, SELECTED_ROW);
   });
   // document.querySelectorAll('[aria-selected]').forEach(selectedEl => {
   //   selectedEl.setAttribute('aria-selected', false);
@@ -87,7 +87,7 @@ export const setSelectedRow = row => {
     document.body.setAttribute('tabindex', '-1');
     document.body.focus();
   });
-  addRemoveClass(row.querySelector(EMAIL_ROW_INNER_CONTAINER), SELECTED_ROW, UNSELECTED_ROW);
+  replaceClass(row.querySelector(EMAIL_ROW_INNER_CONTAINER), SELECTED_ROW, UNSELECTED_ROW);
 };
 
 export const findNextVisibleRow = (currentRow, searchNext = true, includeTimeRows = false) => {

--- a/src/js/shared/utils.js
+++ b/src/js/shared/utils.js
@@ -110,7 +110,7 @@ export const removeClass = (element, className) => {
   }
 };
 
-export const addRemoveClass = (element, classToAdd, classToRemove) => {
+export const replaceClass = (element, classToAdd, classToRemove) => {
   if (classToAdd === classToRemove) {
     return;
   }

--- a/src/scss/outlook/bundle.scss
+++ b/src/scss/outlook/bundle.scss
@@ -15,17 +15,18 @@
     }
   }
 
-  [aria-checked='false'] .ms-Check {
+  [aria-checked='false'] .ms-Checkbox {
     display: none;
   }
 
   &:hover,
   [aria-checked='true'] {
+    .fui-Avatar,
     .ms-Persona-coin {
       display: none;
     }
 
-    .ms-Check {
+    .ms-Checkbox {
       display: block;
     }
   }
@@ -48,5 +49,10 @@
     border: 1px solid;
     padding: 2px 12px;
     display: inline-block;
+  }
+
+  // from column
+  .jHAG3 {
+    padding-left: 32px;
   }
 }

--- a/src/scss/outlook/email-list.scss
+++ b/src/scss/outlook/email-list.scss
@@ -28,8 +28,9 @@ html[dir='ltr'] {
 
             //email list scroll container
             .jEpCF {
-              padding-left: 18px;
+              padding-left: 0;
               height: unset !important;
+              scrollbar-gutter: auto;
 
               //email rows container
               > div {
@@ -46,7 +47,6 @@ html[dir='ltr'] {
             // email column headers
             > div:nth-child(2) {
               box-shadow: rgb(0 0 0 / 24%) -2px -2px 4px;
-              margin: 0 18px;
               padding: 0 !important;
             }
 

--- a/src/scss/outlook/email-preview.scss
+++ b/src/scss/outlook/email-preview.scss
@@ -57,16 +57,21 @@
     }
 
     &.show-preview {
-      left: 18px;
+      left: 2px;
     }
 
     // message header
     .XV5zJ,
     .NTPm6 {
-      margin: 0;
+      margin: 0 !important;
       border: none;
       border-radius: 0;
       border-bottom: 1px solid var(--themeLighter);
+    }
+
+    // custom scrollbar container
+    .yyYQP {
+      scrollbar-gutter: auto;
     }
 
     // show more messages button
@@ -139,7 +144,7 @@
 
     &.bundle-preview {
       &:not(.preview-compose) {
-        left: 30px; //18px padding-left on main + 12px margin on bundle
+        left: 14px;
       }
 
       .AJYpX,

--- a/src/scss/outlook/index.scss
+++ b/src/scss/outlook/index.scss
@@ -42,19 +42,29 @@
         .rEzfP {
           padding: 0;
 
+          // another container in Inbox bar
+          .brFj8 {
+            height: 40px;
+            margin-bottom: 0;
+          }
+
           // Inbox span
           .vlQVl {
             display: none;
           }
 
+          // enable checkboxes button
+          .ac0xq {
+            display: none;
+          }
           // select all container
           .ZYym6 {
-            margin-bottom: 3px;
-            margin-right: 4px;
+            margin: 0;
+            height: 40px;
+            visibility: visible;
 
             [role='checkbox'] {
               margin-left: 0;
-              height: 34px;
 
               &:hover {
                 background-color: var(--neutralLight);
@@ -62,13 +72,24 @@
             }
 
             [role='button'] {
-              height: 34px;
               border-radius: 0;
-              margin-right: 0;
 
               &:hover {
                 background-color: var(--neutralLight);
               }
+            }
+          }
+          // set favorite (star) container
+          .IG8s8 {
+            margin: 0 !important;
+            padding: 0;
+          }
+          // filter container
+          .p4pwT {
+            position: initial;
+            padding-right: 15px;
+            [role='button']:hover {
+              background-color: var(--neutralLight);
             }
           }
         }


### PR DESCRIPTION
- update bundle DOM to match new checkbox/avatar
- tweak bundle checkbox handling based on new checkbox structure
- update checkbox classes in constants based on new DOM
- use computedStyle for label colors
- preview probably only has one child now
- rename addRemoveClass as replaceClass
- adjust preview sizing and remove scrollbar-gutters
- adjust styles for the moved select all and filter bar